### PR TITLE
Migrate Network to react-query.

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -3,11 +3,16 @@ import styled from 'styled-components';
 
 type ButtonProps = {
 	text: string;
-	isActive: boolean;
+	isActive?: boolean;
+	onClick: Function;
 };
 
-const Button: FC<ButtonProps> = ({ text, isActive }) => {
-	return <ButtonContainer isActive={isActive}>{text}</ButtonContainer>;
+const Button: FC<ButtonProps> = ({ text, isActive = false, onClick }) => {
+	return (
+		<ButtonContainer isActive={isActive} onClick={(e) => onClick(e)}>
+			{text}
+		</ButtonContainer>
+	);
 };
 
 export default Button;

--- a/components/Charts/AreaChart.tsx
+++ b/components/Charts/AreaChart.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import React, { FC } from 'react';
 import styled from 'styled-components';
 
 import BasicAreaChart from './BasicAreaChart';
@@ -7,6 +7,7 @@ import ChartTitle from './ChartTitle';
 import { MAX_PAGE_WIDTH, NumberStyle } from '../../constants/styles';
 import { ChartPeriod, AreaChartData } from '../../types/data';
 import { TimeSeriesType } from '../../utils/formatter';
+import Retry from 'components/Retry';
 
 interface AreaChartProps {
 	data: Array<AreaChartData>;
@@ -19,6 +20,8 @@ interface AreaChartProps {
 	timeSeries: TimeSeriesType;
 	activePeriod: ChartPeriod;
 	infoData: React.ReactNode;
+	isError?: boolean;
+	onRefetch?: Function;
 }
 
 const AreaChart: FC<AreaChartProps> = ({
@@ -32,19 +35,27 @@ const AreaChart: FC<AreaChartProps> = ({
 	percentChange,
 	timeSeries,
 	infoData,
+	isError = false,
+	onRefetch = () => {},
 }) => (
 	<ChartContainer>
-		<ChartHeader>
-			<ChartTitle
-				infoData={infoData}
-				title={title}
-				num={num}
-				numFormat={numFormat}
-				percentChange={percentChange}
-			/>
-			<ChartTimeSelectors activePeriod={activePeriod} periods={periods} onClick={onPeriodSelect} />
-		</ChartHeader>
-		<BasicAreaChart valueType={numFormat} data={data} timeSeries={timeSeries} />
+		<Retry isError={isError} onRefetch={onRefetch}>
+			<ChartHeader>
+				<ChartTitle
+					infoData={infoData}
+					title={title}
+					num={num}
+					numFormat={numFormat}
+					percentChange={percentChange}
+				/>
+				<ChartTimeSelectors
+					activePeriod={activePeriod}
+					periods={periods}
+					onClick={onPeriodSelect}
+				/>
+			</ChartHeader>
+			<BasicAreaChart valueType={numFormat} data={data} timeSeries={timeSeries} />
+		</Retry>
 	</ChartContainer>
 );
 

--- a/components/Retry.tsx
+++ b/components/Retry.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { FC, FunctionComponent } from 'react';
+import styled from 'styled-components';
+import Button from './Button';
+
+type RetryProps = {
+	isError: boolean;
+	onRefetch: Function;
+	children: React.ReactNode;
+};
+
+const Retry = ({ isError, onRefetch, children }: RetryProps) => {
+	const [error, setError] = useState(true);
+	return (
+		<RetryContainer>
+			{isError ? (
+				<>
+					<div>Error fetching data</div>
+					<Button
+						onClick={(e: any) => {
+							onRefetch();
+							setError(false);
+						}}
+						text="Refetch"
+					/>
+				</>
+			) : (
+				children
+			)}
+		</RetryContainer>
+	);
+};
+export default Retry;
+
+const RetryContainer = styled.div`
+	height: 100%;
+	width: 100%;
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-around;
+	font-size: 20px;
+`;

--- a/components/StatsBox.tsx
+++ b/components/StatsBox.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { Skeleton } from '@material-ui/lab';
 import styled, { css } from 'styled-components';
 
@@ -6,6 +6,7 @@ import { getFormattedNumber } from 'utils/formatter';
 import { COLORS, NumberColor, NumberStyle } from 'constants/styles';
 import { PercentChangeBox } from './common';
 import InfoPopover from './InfoPopover';
+import Retry from 'components/Retry';
 
 interface StatsBoxProps {
 	title: string;
@@ -16,6 +17,8 @@ interface StatsBoxProps {
 	numberStyle: NumberStyle;
 	numBoxes: number;
 	infoData: ReactNode | null;
+	onRefetch?: Function;
+	isError?: boolean;
 }
 
 // TODO what if num is 0 and is supposed to be zero!!
@@ -28,31 +31,35 @@ const StatsBox: FC<StatsBoxProps> = ({
 	numberStyle,
 	numBoxes,
 	infoData,
+	isError = false,
+	onRefetch = () => {},
 }) => {
 	const formattedNumber = getFormattedNumber(num, numberStyle);
 	return (
 		<StatsBoxContainer num={num} numBoxes={numBoxes}>
-			{num == null ? (
-				<Skeleton
-					className="stats-box-skeleton"
-					variant="rect"
-					animation="wave"
-					width="100%"
-					height="100%"
-				/>
-			) : (
-				<>
-					<TitleWrapper>
-						<StatsBoxTitle>{title}</StatsBoxTitle>
-						{infoData != null ? <InfoPopover infoData={infoData} /> : null}
-					</TitleWrapper>
-					<StatsBoxNumber color={color}>{formattedNumber}</StatsBoxNumber>
-					{percentChange != null ? (
-						<PercentChangeBox color={color}>{percentChange}</PercentChangeBox>
-					) : null}
-					<StatsBoxSubText>{subText}</StatsBoxSubText>
-				</>
-			)}
+			<Retry isError={isError} onRefetch={onRefetch}>
+				{num == null ? (
+					<Skeleton
+						className="stats-box-skeleton"
+						variant="rect"
+						animation="wave"
+						width="100%"
+						height="100%"
+					/>
+				) : (
+					<>
+						<TitleWrapper>
+							<StatsBoxTitle>{title}</StatsBoxTitle>
+							{infoData != null ? <InfoPopover infoData={infoData} /> : null}
+						</TitleWrapper>
+						<StatsBoxNumber color={color}>{formattedNumber}</StatsBoxNumber>
+						{percentChange != null ? (
+							<PercentChangeBox color={color}>{percentChange}</PercentChangeBox>
+						) : null}
+						<StatsBoxSubText>{subText}</StatsBoxSubText>
+					</>
+				)}
+			</Retry>
 		</StatsBoxContainer>
 	);
 };

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -1,0 +1,76 @@
+import { BigNumber } from 'ethers';
+import { QueryKeyOrPredicateFn, QueryKeyPart } from 'react-query';
+import { ChartPeriod } from 'types/data';
+
+const QUERY_KEYS = {
+	Contracts: {
+		EtherCollateralsUSD: {
+			TotalIssuedSynths: ['contracts', 'etherCollateralUSD', 'totalIssuedSynths'],
+		},
+		ExchangeRates: {
+			RateForCurrency: (name: string): QueryKeyOrPredicateFn => [
+				'contracts',
+				'exchangeRates',
+				name,
+			],
+		},
+		Synthetix: {
+			TotalSupply: ['contracts', 'synthetix', 'totalSupply'] as QueryKeyOrPredicateFn,
+			LastDebtLedgerEntry: ['contracts', 'synthetix', 'lastDebtLedgerEntry'],
+			TotalIssuedSynthsExcludeEtherCollateral: (name: string) => [
+				'contracts',
+				'synthetix',
+				'totalIssuedSynthsExcludeEtherCollateral',
+				name,
+			],
+			Network: {
+				Meta: ['contracts', 'synthetix', 'network', 'meta'],
+			},
+		},
+		SynthetixState: {
+			IssuanceRatio: ['contracts', 'synthetixState', 'issuanceRatio'],
+		},
+		SynthsUSD: {
+			TotalSupply: ['contracts', 'synthsUSD', 'totalSupply'],
+		},
+		Curve: {
+			GetDYUnderlying: (
+				susdContractNumber: number,
+				usdcContractNumber: number,
+				susdAmountWei: BigNumber
+			): QueryKeyOrPredicateFn => [
+				'contracts',
+				'curve',
+				susdContractNumber,
+				usdcContractNumber,
+				susdAmountWei,
+			],
+		},
+	},
+	SNXData: {
+		SNX: {
+			Holders: ['snxData', 'snx', 'holders'],
+			Total: ['snxData', 'snx', 'total'],
+		},
+		Synths: {
+			Holders: (synth: string) => ['snxData', 'synths', 'total', synth],
+		},
+		Rate: {
+			SNXAggregate: (timeseries: string, max: number) => [
+				'snxData',
+				'rate',
+				'snxAggregate',
+				timeseries,
+				max,
+			],
+		},
+	},
+	CMC: {
+		Price: (name: string): QueryKeyOrPredicateFn => ['cmc', 'price', name],
+	},
+	Wallet: {
+		Balance: (address: string) => ['wallet', 'balance', address],
+	},
+};
+
+export default QUERY_KEYS;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,26 +5,26 @@
 	"requires": true,
 	"dependencies": {
 		"@ampproject/toolbox-core": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/toolbox-core/-/toolbox-core-2.6.0.tgz",
-			"integrity": "sha512-sDMnHj8WaX3tqJS5VsIHkeW98nq5WQ0C9RoFc1PPS3rmYIlS0vhAfHbrjJw6wtuxBTQFxccje+Ew+2OJ2D15kA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@ampproject/toolbox-core/-/toolbox-core-2.6.1.tgz",
+			"integrity": "sha512-hTsd9J2yy3JPMClG8BuUhUfMDtd3oDhCuRe/SyZJYQfNMN8hQHt7LNXtdOzZr0Kw7nTepHmn7GODS68fZN4OQQ==",
 			"requires": {
-				"cross-fetch": "3.0.5",
+				"cross-fetch": "3.0.6",
 				"lru-cache": "6.0.0"
 			},
 			"dependencies": {
 				"cross-fetch": {
-					"version": "3.0.5",
-					"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
-					"integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+					"version": "3.0.6",
+					"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+					"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
 					"requires": {
-						"node-fetch": "2.6.0"
+						"node-fetch": "2.6.1"
 					}
 				},
 				"node-fetch": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 				}
 			}
 		},
@@ -198,14 +198,14 @@
 					}
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001137",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz",
-					"integrity": "sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw=="
+					"version": "1.0.30001148",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
+					"integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw=="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.574",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.574.tgz",
-					"integrity": "sha512-kF8Bfe1h8X1pPwlw6oRoIXj0DevowviP6fl0wcljm+nZjy/7+Fos4THo1N/7dVGEJlyEqK9C8qNnbheH+Eazfw=="
+					"version": "1.3.578",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.578.tgz",
+					"integrity": "sha512-z4gU6dA1CbBJsAErW5swTGAaU2TBzc2mPAonJb00zqW1rOraDo2zfBMDRvaz9cVic+0JEZiYbHWPw/fTaZlG2Q=="
 				}
 			}
 		},
@@ -342,14 +342,14 @@
 					}
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001137",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz",
-					"integrity": "sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw=="
+					"version": "1.0.30001148",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
+					"integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw=="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.574",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.574.tgz",
-					"integrity": "sha512-kF8Bfe1h8X1pPwlw6oRoIXj0DevowviP6fl0wcljm+nZjy/7+Fos4THo1N/7dVGEJlyEqK9C8qNnbheH+Eazfw=="
+					"version": "1.3.578",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.578.tgz",
+					"integrity": "sha512-z4gU6dA1CbBJsAErW5swTGAaU2TBzc2mPAonJb00zqW1rOraDo2zfBMDRvaz9cVic+0JEZiYbHWPw/fTaZlG2Q=="
 				}
 			}
 		},
@@ -1329,14 +1329,14 @@
 					}
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001137",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz",
-					"integrity": "sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw=="
+					"version": "1.0.30001148",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
+					"integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw=="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.574",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.574.tgz",
-					"integrity": "sha512-kF8Bfe1h8X1pPwlw6oRoIXj0DevowviP6fl0wcljm+nZjy/7+Fos4THo1N/7dVGEJlyEqK9C8qNnbheH+Eazfw=="
+					"version": "1.3.578",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.578.tgz",
+					"integrity": "sha512-z4gU6dA1CbBJsAErW5swTGAaU2TBzc2mPAonJb00zqW1rOraDo2zfBMDRvaz9cVic+0JEZiYbHWPw/fTaZlG2Q=="
 				}
 			}
 		},
@@ -1465,74 +1465,6 @@
 				"@babel/helper-validator-identifier": "^7.10.4",
 				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
-			}
-		},
-		"@chainlink/contracts-0.0.10": {
-			"version": "npm:@chainlink/contracts@0.0.10",
-			"resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
-			"integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
-			"requires": {
-				"@truffle/contract": "^4.2.6",
-				"ethers": "^4.0.45"
-			},
-			"dependencies": {
-				"aes-js": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-					"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-					"optional": true
-				},
-				"ethers": {
-					"version": "4.0.48",
-					"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
-					"integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
-					"optional": true,
-					"requires": {
-						"aes-js": "3.0.0",
-						"bn.js": "^4.4.0",
-						"elliptic": "6.5.3",
-						"hash.js": "1.1.3",
-						"js-sha3": "0.5.7",
-						"scrypt-js": "2.0.4",
-						"setimmediate": "1.0.4",
-						"uuid": "2.0.1",
-						"xmlhttprequest": "1.8.0"
-					}
-				},
-				"hash.js": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-					"optional": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"minimalistic-assert": "^1.0.0"
-					}
-				},
-				"js-sha3": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-					"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-					"optional": true
-				},
-				"scrypt-js": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-					"integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
-					"optional": true
-				},
-				"setimmediate": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-					"integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-					"optional": true
-				},
-				"uuid": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-					"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-					"optional": true
-				}
 			}
 		},
 		"@chaitanyapotti/random-id": {
@@ -2038,6 +1970,28 @@
 				"@ethersproject/strings": "^5.0.3"
 			}
 		},
+		"@hapi/accept": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
+			"integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/boom": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+			"integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+			"requires": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/hoek": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+			"integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+		},
 		"@ledgerhq/devices": {
 			"version": "5.22.0",
 			"resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.22.0.tgz",
@@ -2170,10 +2124,20 @@
 				"react-is": "^16.8.0"
 			}
 		},
+		"@next/env": {
+			"version": "9.5.5",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-9.5.5.tgz",
+			"integrity": "sha512-N9wdjU6XoqLqNQWtrGiWtp1SUuJsYK1cNrZ24A6YD+4w5CNV5SkZX6aewKZCCLP5Y8UNfTij2FkJiSYUfBjX8g=="
+		},
+		"@next/polyfill-module": {
+			"version": "9.5.5",
+			"resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-9.5.5.tgz",
+			"integrity": "sha512-itqYFeHo3yN4ccpHq2uNFC2UVQm12K6DxUVwYdui9MJiiueT0pSGb2laYEjf/G5+vVq7M2vb+DkjkOkPMBVfeg=="
+		},
 		"@next/react-dev-overlay": {
-			"version": "9.5.3",
-			"resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-9.5.3.tgz",
-			"integrity": "sha512-R2ZAyFjHHaMTBVi19ZZNRJNXiwn46paRi7EZvKNvMxbrzBcUYtSFj/edU3jQoF1UOcC6vGeMhtPqH55ONrIjCQ==",
+			"version": "9.5.5",
+			"resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-9.5.5.tgz",
+			"integrity": "sha512-B1nDANxjXr2oyohv+tX0OXZTmJtO5qEWmisNPGnqQ2Z32IixfaAgyNYVuCVf20ap6EUz5elhgNUwRIFh/e26mQ==",
 			"requires": {
 				"@babel/code-frame": "7.10.4",
 				"ally.js": "1.4.1",
@@ -2201,11 +2165,10 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -2263,9 +2226,24 @@
 			}
 		},
 		"@next/react-refresh-utils": {
-			"version": "9.5.3",
-			"resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-9.5.3.tgz",
-			"integrity": "sha512-W3VKOqbg+4Kw+k6M/SODf+WIzwcx60nAemGV1nNPa/yrDtAS2YcJfqiswrJ3+2nJHzqefAFWn4XOfM0fy8ww2Q=="
+			"version": "9.5.5",
+			"resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-9.5.5.tgz",
+			"integrity": "sha512-Gz5z0+ID+KAGto6Tkgv1a340damEw3HG6ANLKwNi5/QSHqQ3JUAVxMuhz3qnL54505I777evpzL89ofWEMIWKw=="
+		},
+		"@npmcli/move-file": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.0.1.tgz",
+			"integrity": "sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==",
+			"requires": {
+				"mkdirp": "^1.0.4"
+			},
+			"dependencies": {
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				}
+			}
 		},
 		"@portis/web3": {
 			"version": "2.0.0-beta.58",
@@ -3591,7 +3569,8 @@
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+			"dev": true
 		},
 		"@types/d3-path": {
 			"version": "1.0.8",
@@ -3636,8 +3615,7 @@
 		"@types/json-schema": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
-			"dev": true
+			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -6149,30 +6127,34 @@
 			"optional": true
 		},
 		"cacache": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
-			"integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+			"version": "15.0.5",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
+			"integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
 			"requires": {
-				"chownr": "^1.1.2",
-				"figgy-pudding": "^3.5.1",
+				"@npmcli/move-file": "^1.0.1",
+				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",
 				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.2",
 				"infer-owner": "^1.0.4",
-				"lru-cache": "^5.1.1",
-				"minipass": "^3.0.0",
+				"lru-cache": "^6.0.0",
+				"minipass": "^3.1.1",
 				"minipass-collect": "^1.0.2",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.2",
-				"mkdirp": "^0.5.1",
-				"move-concurrently": "^1.0.1",
-				"p-map": "^3.0.0",
+				"mkdirp": "^1.0.3",
+				"p-map": "^4.0.0",
 				"promise-inflight": "^1.0.1",
-				"rimraf": "^2.7.1",
-				"ssri": "^7.0.0",
+				"rimraf": "^3.0.2",
+				"ssri": "^8.0.0",
+				"tar": "^6.0.2",
 				"unique-filename": "^1.1.1"
 			},
 			"dependencies": {
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+				},
 				"fs-minipass": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -6181,26 +6163,38 @@
 						"minipass": "^3.0.0"
 					}
 				},
-				"lru-cache": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-					"requires": {
-						"yallist": "^3.0.2"
-					},
-					"dependencies": {
-						"yallist": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-							"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-						}
-					}
-				},
 				"minipass": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
 					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+					"requires": {
+						"minipass": "^3.0.0",
+						"yallist": "^4.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				},
+				"tar": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+					"integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+					"requires": {
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"minipass": "^3.0.0",
+						"minizlib": "^2.1.1",
+						"mkdirp": "^1.0.3",
 						"yallist": "^4.0.0"
 					}
 				},
@@ -6541,16 +6535,6 @@
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
 			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
-		"clone-deep": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-			"requires": {
-				"is-plain-object": "^2.0.4",
-				"kind-of": "^6.0.2",
-				"shallow-clone": "^3.0.0"
-			}
-		},
 		"clone-response": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -6761,6 +6745,16 @@
 				"mkdirp": "^0.5.1",
 				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.0"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"copy-descriptor": {
@@ -6794,14 +6788,14 @@
 					}
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001137",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz",
-					"integrity": "sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw=="
+					"version": "1.0.30001148",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
+					"integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw=="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.574",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.574.tgz",
-					"integrity": "sha512-kF8Bfe1h8X1pPwlw6oRoIXj0DevowviP6fl0wcljm+nZjy/7+Fos4THo1N/7dVGEJlyEqK9C8qNnbheH+Eazfw=="
+					"version": "1.3.578",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.578.tgz",
+					"integrity": "sha512-z4gU6dA1CbBJsAErW5swTGAaU2TBzc2mPAonJb00zqW1rOraDo2zfBMDRvaz9cVic+0JEZiYbHWPw/fTaZlG2Q=="
 				},
 				"semver": {
 					"version": "7.0.0",
@@ -6969,47 +6963,43 @@
 			"integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
 		},
 		"css-loader": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.5.3.tgz",
-			"integrity": "sha512-UEr9NH5Lmi7+dguAm+/JSPovNjYbm2k3TK58EiwQHzOHH5Jfq1Y+XoP2bQO6TMn7PptMd0opxxedAWcaSTRKHw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-4.3.0.tgz",
+			"integrity": "sha512-rdezjCjScIrsL8BSYszgT4s476IcNKt6yX69t0pHjJVnPUTDpn4WfIpDQTN3wCJvUvfsz/mFjuGOekf3PY3NUg==",
 			"requires": {
-				"camelcase": "^5.3.1",
+				"camelcase": "^6.0.0",
 				"cssesc": "^3.0.0",
 				"icss-utils": "^4.1.1",
-				"loader-utils": "^1.2.3",
-				"normalize-path": "^3.0.0",
-				"postcss": "^7.0.27",
+				"loader-utils": "^2.0.0",
+				"postcss": "^7.0.32",
 				"postcss-modules-extract-imports": "^2.0.0",
-				"postcss-modules-local-by-default": "^3.0.2",
+				"postcss-modules-local-by-default": "^3.0.3",
 				"postcss-modules-scope": "^2.2.0",
 				"postcss-modules-values": "^3.0.0",
-				"postcss-value-parser": "^4.0.3",
-				"schema-utils": "^2.6.6",
-				"semver": "^6.3.0"
+				"postcss-value-parser": "^4.1.0",
+				"schema-utils": "^2.7.1",
+				"semver": "^7.3.2"
 			},
 			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"requires": {
-						"minimist": "^1.2.0"
-					}
+				"camelcase": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
 				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+				"schema-utils": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+					"integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
 					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
+						"@types/json-schema": "^7.0.5",
+						"ajv": "^6.12.4",
+						"ajv-keywords": "^3.5.2"
 					}
 				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				}
 			}
 		},
@@ -7927,9 +7917,9 @@
 			}
 		},
 		"escalade": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
-			"integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig=="
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -11737,6 +11727,11 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
 		},
+		"klona": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+			"integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
+		},
 		"language-subtag-registry": {
 			"version": "0.3.20",
 			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz",
@@ -12911,6 +12906,16 @@
 				"mkdirp": "^0.5.1",
 				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"ms": {
@@ -13021,21 +13026,20 @@
 			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
 		},
 		"next": {
-			"version": "9.5.3",
-			"resolved": "https://registry.npmjs.org/next/-/next-9.5.3.tgz",
-			"integrity": "sha512-DGrpTNGV2RNMwLaSzpgbkbaUuVk30X71/roXHS10isSXo2Gm+qWcjonDyOxf1KmOvHZRHA/Fa+LaAR7ysdYS3A==",
+			"version": "9.5.5",
+			"resolved": "https://registry.npmjs.org/next/-/next-9.5.5.tgz",
+			"integrity": "sha512-KF4MIdTYeI6YIGODNw27w9HGzCll4CXbUpkP6MNvyoHlpsunx8ybkQHm/hYa7lWMozmsn58LwaXJOhe4bSrI0g==",
 			"requires": {
 				"@ampproject/toolbox-optimizer": "2.6.0",
 				"@babel/code-frame": "7.10.4",
 				"@babel/core": "7.7.7",
 				"@babel/plugin-proposal-class-properties": "7.10.4",
 				"@babel/plugin-proposal-export-namespace-from": "7.10.4",
-				"@babel/plugin-proposal-nullish-coalescing-operator": "7.10.4",
 				"@babel/plugin-proposal-numeric-separator": "7.10.4",
 				"@babel/plugin-proposal-object-rest-spread": "7.11.0",
-				"@babel/plugin-proposal-optional-chaining": "7.11.0",
 				"@babel/plugin-syntax-bigint": "7.8.3",
 				"@babel/plugin-syntax-dynamic-import": "7.8.3",
+				"@babel/plugin-syntax-jsx": "7.10.4",
 				"@babel/plugin-transform-modules-commonjs": "7.10.4",
 				"@babel/plugin-transform-runtime": "7.11.5",
 				"@babel/preset-env": "7.11.5",
@@ -13044,19 +13048,21 @@
 				"@babel/preset-typescript": "7.10.4",
 				"@babel/runtime": "7.11.2",
 				"@babel/types": "7.11.5",
-				"@next/react-dev-overlay": "9.5.3",
-				"@next/react-refresh-utils": "9.5.3",
+				"@hapi/accept": "5.0.1",
+				"@next/env": "9.5.5",
+				"@next/polyfill-module": "9.5.5",
+				"@next/react-dev-overlay": "9.5.5",
+				"@next/react-refresh-utils": "9.5.5",
 				"ast-types": "0.13.2",
-				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-define": "2.0.0",
 				"babel-plugin-transform-react-remove-prop-types": "0.4.24",
 				"browserslist": "4.13.0",
 				"buffer": "5.6.0",
-				"cacache": "13.0.1",
+				"cacache": "15.0.5",
 				"caniuse-lite": "^1.0.30001113",
 				"chokidar": "2.1.8",
 				"crypto-browserify": "3.12.0",
-				"css-loader": "3.5.3",
+				"css-loader": "4.3.0",
 				"cssnano-simple": "1.2.0",
 				"find-cache-dir": "3.3.1",
 				"jest-worker": "24.9.0",
@@ -13073,15 +13079,15 @@
 				"react-is": "16.13.1",
 				"react-refresh": "0.8.3",
 				"resolve-url-loader": "3.1.1",
-				"sass-loader": "8.0.2",
-				"schema-utils": "2.6.6",
+				"sass-loader": "10.0.2",
+				"schema-utils": "2.7.1",
 				"stream-browserify": "3.0.0",
 				"style-loader": "1.2.1",
 				"styled-jsx": "3.3.0",
 				"use-subscription": "1.4.1",
 				"vm-browserify": "1.1.2",
 				"watchpack": "2.0.0-beta.13",
-				"web-vitals": "0.2.1",
+				"web-vitals": "0.2.4",
 				"webpack": "4.44.1",
 				"webpack-sources": "1.4.3"
 			},
@@ -13138,6 +13144,16 @@
 					"version": "0.11.10",
 					"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
 					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+				},
+				"schema-utils": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+					"integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+					"requires": {
+						"@types/json-schema": "^7.0.5",
+						"ajv": "^6.12.4",
+						"ajv-keywords": "^3.5.2"
+					}
 				}
 			}
 		},
@@ -13177,9 +13193,9 @@
 			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"node-html-parser": {
-			"version": "1.2.21",
-			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.2.21.tgz",
-			"integrity": "sha512-6vDhgen6J332syN5HUmeT4FfBG7m6bFRrPN+FXY8Am7FGuVpsIxTASVbeoO5PF2IHbX2s+WEIudb1hgxOjllNQ==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.3.1.tgz",
+			"integrity": "sha512-AwYVI6GyEKj9NGoyMfSx4j5l7Axf7obQgLWGxtasLjED6RggTTQoq5ZRzjwSUfgSZ+Mv8Nzbi3pID0gFGqNUsA==",
 			"requires": {
 				"he": "1.2.0"
 			}
@@ -13569,11 +13585,6 @@
 			"integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
 			"dev": true
 		},
-		"openzeppelin-solidity-2.3.0": {
-			"version": "npm:openzeppelin-solidity@2.3.0",
-			"resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-			"integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
-		},
 		"optionator": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -13632,9 +13643,9 @@
 			}
 		},
 		"p-map": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
 			"requires": {
 				"aggregate-error": "^3.0.0"
 			}
@@ -15038,9 +15049,9 @@
 			"integrity": "sha1-mUWygD8hni96ygCtuLyfZA+ELJo="
 		},
 		"rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -15122,39 +15133,36 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sass-loader": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
-			"integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.0.2.tgz",
+			"integrity": "sha512-wV6NDUVB8/iEYMalV/+139+vl2LaRFlZGEd5/xmdcdzQcgmis+npyco6NsDTVOlNA3y2NV9Gcz+vHyFMIT+ffg==",
 			"requires": {
-				"clone-deep": "^4.0.1",
-				"loader-utils": "^1.2.3",
-				"neo-async": "^2.6.1",
-				"schema-utils": "^2.6.1",
-				"semver": "^6.3.0"
+				"klona": "^2.0.3",
+				"loader-utils": "^2.0.0",
+				"neo-async": "^2.6.2",
+				"schema-utils": "^2.7.1",
+				"semver": "^7.3.2"
 			},
 			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"requires": {
-						"minimist": "^1.2.0"
-					}
+				"neo-async": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+					"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
 				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+				"schema-utils": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+					"integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
 					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
+						"@types/json-schema": "^7.0.5",
+						"ajv": "^6.12.4",
+						"ajv-keywords": "^3.5.2"
 					}
 				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				}
 			}
 		},
@@ -15345,14 +15353,6 @@
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
-			}
-		},
-		"shallow-clone": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-			"requires": {
-				"kind-of": "^6.0.2"
 			}
 		},
 		"shallow-equal": {
@@ -15775,11 +15775,10 @@
 			}
 		},
 		"ssri": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-			"integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+			"integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
 			"requires": {
-				"figgy-pudding": "^3.5.1",
 				"minipass": "^3.1.1"
 			},
 			"dependencies": {
@@ -16331,6 +16330,21 @@
 				"web3-utils": "1.2.2"
 			},
 			"dependencies": {
+				"@chainlink/contracts-0.0.10": {
+					"version": "npm:@chainlink/contracts@0.0.10",
+					"resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
+					"integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
+					"requires": {
+						"@truffle/contract": "^4.2.6",
+						"ethers": "^4.0.45"
+					}
+				},
+				"aes-js": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+					"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
+					"optional": true
+				},
 				"bn.js": {
 					"version": "4.11.8",
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -16350,6 +16364,62 @@
 						"elliptic": "^6.4.0",
 						"xhr-request-promise": "^0.1.2"
 					}
+				},
+				"ethers": {
+					"version": "4.0.48",
+					"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+					"integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+					"optional": true,
+					"requires": {
+						"aes-js": "3.0.0",
+						"bn.js": "^4.4.0",
+						"elliptic": "6.5.3",
+						"hash.js": "1.1.3",
+						"js-sha3": "0.5.7",
+						"scrypt-js": "2.0.4",
+						"setimmediate": "1.0.4",
+						"uuid": "2.0.1",
+						"xmlhttprequest": "1.8.0"
+					}
+				},
+				"hash.js": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+					"optional": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.0"
+					}
+				},
+				"js-sha3": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+					"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+					"optional": true
+				},
+				"openzeppelin-solidity-2.3.0": {
+					"version": "npm:openzeppelin-solidity@2.3.0",
+					"resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+					"integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
+				},
+				"scrypt-js": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+					"integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+					"optional": true
+				},
+				"setimmediate": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+					"integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+					"optional": true
+				},
+				"uuid": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+					"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+					"optional": true
 				},
 				"web3-utils": {
 					"version": "1.2.2",
@@ -16994,6 +17064,14 @@
 					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 					"requires": {
 						"find-up": "^3.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				},
 				"schema-utils": {
@@ -17692,9 +17770,9 @@
 			}
 		},
 		"web-vitals": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.1.tgz",
-			"integrity": "sha512-2pdRlp6gJpOCg0oMMqwFF0axjk5D9WInc09RSYtqFgPXQ15+YKNQ7YnBBEqAL5jvmfH9WvoXDMb8DHwux7pIew=="
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
+			"integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="
 		},
 		"web3": {
 			"version": "0.20.7",
@@ -19347,9 +19425,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+					"version": "6.4.2",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+					"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
 				},
 				"anymatch": {
 					"version": "3.1.1",
@@ -19377,9 +19455,9 @@
 					}
 				},
 				"chokidar": {
-					"version": "3.4.2",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-					"integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
 					"optional": true,
 					"requires": {
 						"anymatch": "~3.1.1",
@@ -19389,7 +19467,7 @@
 						"is-binary-path": "~2.1.0",
 						"is-glob": "~4.0.1",
 						"normalize-path": "~3.0.0",
-						"readdirp": "~3.4.0"
+						"readdirp": "~3.5.0"
 					}
 				},
 				"fill-range": {
@@ -19450,9 +19528,9 @@
 					}
 				},
 				"readdirp": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-					"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+					"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
 					"optional": true,
 					"requires": {
 						"picomatch": "^2.2.1"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -135,10 +135,10 @@ const App: FC<AppProps> = ({ Component, pageProps }) => {
 						<SNXJSContext.Provider value={snxjs}>
 							<ProviderContext.Provider value={provider}>
 								{/*
-	              // @ts-ignore */}
+				// @ts-ignore */}
 								<SUSDContext.Provider value={{ sUSDPrice, setsUSDPrice }}>
 									{/*
-									// @ts-ignore */}
+								// @ts-ignore */}
 									<SNXContext.Provider value={{ SNXPrice, setSNXPrice, SNXStaked, setSNXStaked }}>
 										<Layout>
 											<Component {...pageProps} />

--- a/queries/cmc.ts
+++ b/queries/cmc.ts
@@ -1,0 +1,32 @@
+import { useQuery, BaseQueryOptions, useQueryCache } from 'react-query';
+import axios from 'axios';
+import QUERY_KEYS from 'constants/queryKeys';
+import useQueryGroup from './useQueryGroup';
+
+const CMC_API = 'https://coinmarketcap-api.synthetix.io/public/prices?symbols=';
+
+type CMC_PRICE = {
+	data: Record<
+		string,
+		{
+			quote: Record<
+				string,
+				{
+					volume_24h: number;
+				}
+			>;
+		}
+	>;
+};
+
+export const useCMCPrice = (name: string, options?: BaseQueryOptions) =>
+	useQuery<CMC_PRICE, any>(QUERY_KEYS.CMC.Price(name), () => axios.get(`${CMC_API}${name}`), {
+		...options,
+	});
+
+export const useCMCVolume = (name: string) =>
+	useQueryGroup([useCMCPrice(name)], (cmcSNXData) =>
+		cmcSNXData.data && cmcSNXData.data.data[name]
+			? cmcSNXData.data.data[name].quote.USD.volume_24h
+			: null
+	);

--- a/queries/curve.ts
+++ b/queries/curve.ts
@@ -1,0 +1,78 @@
+import { useQuery, BaseQueryOptions, useQueryCache } from 'react-query';
+import QUERY_KEYS from 'constants/queryKeys';
+import { BigNumber, Contract, ethers } from 'ethers';
+import { curveSusdPool } from 'contracts';
+import { SNXJSContext, ProviderContext, SUSDContext } from 'pages/_app';
+import { useContext } from 'react';
+
+export const useDYUnderlying = (
+	curveContract: Contract,
+	susdContractNumber: number,
+	usdcContractNumber: number,
+	susdAmountWei: BigNumber,
+	options?: BaseQueryOptions
+) =>
+	useQuery<BigNumber, any>(
+		QUERY_KEYS.Contracts.Curve.GetDYUnderlying(
+			susdContractNumber,
+			usdcContractNumber,
+			susdAmountWei
+		),
+		() => curveContract.get_dy_underlying(susdContractNumber, usdcContractNumber, susdAmountWei),
+		{ ...options }
+	);
+
+export const useSUSDPrice = () => {
+	const snxjs = useContext(SNXJSContext);
+	const provider = useContext(ProviderContext);
+	const { setsUSDPrice } = useContext(SUSDContext);
+	const { formatUnits } = snxjs.utils;
+
+	const usdcContractNumber = 1;
+	const susdContractNumber = 3;
+	const susdAmount = 10000;
+	const susdAmountWei = snxjs.utils.parseUnits(susdAmount.toString(), 18);
+
+	const curveContract = new ethers.Contract(
+		curveSusdPool.address,
+		// @ts-ignore
+		curveSusdPool.abi,
+		provider
+	);
+
+	const unformattedExchangeAmountQuery = useDYUnderlying(
+		curveContract,
+		susdContractNumber,
+		usdcContractNumber,
+		susdAmountWei
+	);
+
+	const exchangeAmount = Number(formatUnits(unformattedExchangeAmountQuery.data || 0, 6));
+	const sUSDPrice = exchangeAmount / susdAmount;
+
+	// TODO consolidate context to use react-query
+	setsUSDPrice(sUSDPrice);
+
+	const queryCache = useQueryCache();
+	const refetch = () =>
+		queryCache.invalidateQueries(
+			QUERY_KEYS.Contracts.Curve.GetDYUnderlying(
+				susdContractNumber,
+				usdcContractNumber,
+				susdAmountWei
+			),
+			{
+				exact: true,
+				throwOnError: true,
+				refetchActive: true,
+				refetchInactive: false,
+			}
+		);
+
+	return {
+		sUSDPrice,
+		isLoading: unformattedExchangeAmountQuery.isLoading,
+		isError: unformattedExchangeAmountQuery.isError,
+		refetch,
+	};
+};

--- a/queries/snxData.ts
+++ b/queries/snxData.ts
@@ -1,0 +1,126 @@
+import { useQuery, BaseQueryOptions, QueryKey } from 'react-query';
+import QUERY_KEYS from 'constants/queryKeys';
+import snxData from 'synthetix-data';
+import {
+	useIssuanceRatio,
+	useLastDebtLedgerEntry,
+	useSynthSUSDTotalSupply,
+	useTotalIssuedSynthsExcludeEtherCollateral,
+} from './snxjs';
+import useQueryGroup from './useQueryGroup';
+import { AreaChartData, ChartPeriod, SNXPriceData, TimeSeries } from 'types/data';
+import { formatIdToIsoString } from 'utils/formatter';
+
+export type SNXHolder = {
+	id: number;
+	block: number;
+	timestamp: Date;
+	balanceOf: number;
+	collateral: number;
+	transferable: number;
+	initialDebtOwnership: number;
+	debtEntryAtIndex: number;
+	claims: number;
+	mints: number;
+};
+
+export const useSNXNetworkMeta = () =>
+	useQueryGroup(
+		[
+			useSNXHolders(),
+			useTotalIssuedSynthsExcludeEtherCollateral('sUSD'),
+			useLastDebtLedgerEntry(),
+			useIssuanceRatio(),
+			useSynthSUSDTotalSupply(),
+		],
+		(holders, totalIssuedSynths, lastDebtLedgerEntry, issuanceRatio, usdToSnxPrice) => {
+			let snxTotal = 0;
+			let snxLocked = 0;
+			let stakersTotalDebt = 0;
+			let stakersTotalCollateral = 0;
+
+			for (const { collateral, debtEntryAtIndex, initialDebtOwnership } of holders) {
+				let debtBalance =
+					((totalIssuedSynths * lastDebtLedgerEntry) / debtEntryAtIndex) * initialDebtOwnership;
+				let collateralRatio = debtBalance / collateral / usdToSnxPrice;
+
+				if (isNaN(debtBalance)) {
+					debtBalance = 0;
+					collateralRatio = 0;
+				}
+				const lockedSnx = collateral * Math.min(1, collateralRatio / issuanceRatio);
+
+				if (Number(debtBalance) > 0) {
+					stakersTotalDebt += Number(debtBalance);
+					stakersTotalCollateral += Number(collateral * usdToSnxPrice);
+				}
+				snxTotal += Number(collateral);
+				snxLocked += Number(lockedSnx);
+			}
+
+			return { snxTotal, snxLocked, stakersTotalDebt, stakersTotalCollateral };
+		}
+	);
+
+export const useSNXHolders = (max: number = 1000, options?: BaseQueryOptions) =>
+	useQuery<Array<SNXHolder>, QueryKey<any>>(
+		QUERY_KEYS.SNXData.SNX.Holders,
+		() => snxData.snx.holders({ max }),
+		{
+			...options,
+		}
+	);
+
+type SNXTotal = {
+	issuers: number;
+	snxHolders: number;
+};
+
+export const useSNXTotal = (options?: BaseQueryOptions) =>
+	useQuery<SNXTotal, QueryKey<any>>(QUERY_KEYS.SNXData.SNX.Total, () => snxData.snx.total(), {
+		...options,
+	});
+
+type SynthHolderBalance = {
+	address: string;
+	balanceOf: number;
+	synth: string;
+};
+
+export const useSynthHolders = (synth: string, max: number = 5, options?: BaseQueryOptions) =>
+	useQuery<Array<SynthHolderBalance>, QueryKey<any>>(
+		QUERY_KEYS.SNXData.Synths.Holders(synth),
+		() => snxData.synths.holders({ synth, max }),
+		{ ...options }
+	);
+
+const CHART_PERIOD_META = {
+	D: { timeseries: '15m', max: 24 * 4 },
+	W: { timeseries: '15m', max: 24 * 4 * 7 },
+	M: { timeseries: '1d', max: 30 },
+	Y: { timeseries: '1d', max: 365 },
+};
+
+export const useChartData = (period: ChartPeriod) => {
+	const { timeseries, max } = CHART_PERIOD_META[period];
+	return useQuery<{ id: number; averagePrice: number }[], QueryKey<any>>(
+		QUERY_KEYS.SNXData.Rate.SNXAggregate(timeseries, max),
+		() =>
+			snxData.rate
+				.snxAggregate({
+					timeseries,
+					max,
+				})
+				.then((response: SNXPriceData[]) =>
+					formatChartData(response.reverse(), timeseries as TimeSeries)
+				)
+	);
+};
+
+const formatChartData = (data: SNXPriceData[], timeSeries: TimeSeries): AreaChartData[] =>
+	(data as SNXPriceData[]).map(({ id, averagePrice }) => {
+		return {
+			created: formatIdToIsoString(id, timeSeries as TimeSeries),
+			value: averagePrice,
+		};
+	});

--- a/queries/snxjs.ts
+++ b/queries/snxjs.ts
@@ -1,0 +1,147 @@
+import { useQuery, BaseQueryOptions, QueryKey } from 'react-query';
+import QUERY_KEYS from 'constants/queryKeys';
+import { BigNumber } from 'ethers';
+import { SNXContext, SNXJSContext } from 'pages/_app';
+import { useContext, useState } from 'react';
+import { useChartData, useSNXNetworkMeta } from './snxData';
+import { useQueryGroup } from './useQueryGroup';
+import { ChartPeriod } from 'types/data';
+
+export const useRateForCurrency = (name: string, options?: BaseQueryOptions) => {
+	const snxjs = useContext(SNXJSContext);
+	return useQuery<BigNumber, QueryKey<any>>(
+		QUERY_KEYS.Contracts.ExchangeRates.RateForCurrency(name),
+		() => snxjs.contracts.ExchangeRates.rateForCurrency(snxjs.toBytes32(name)),
+		{ ...options }
+	);
+};
+
+export const useTotalSupply = (options?: BaseQueryOptions) => {
+	const snxjs = useContext(SNXJSContext);
+	return useQuery<BigNumber, QueryKey<any>>(
+		QUERY_KEYS.Contracts.Synthetix.TotalSupply,
+		() => snxjs.contracts.Synthetix.totalSupply(),
+		{ ...options }
+	);
+};
+
+export const useLastDebtLedgerEntry = (options?: BaseQueryOptions) => {
+	const snxjs = useContext(SNXJSContext);
+	return useQuery<BigNumber, QueryKey<any>>(
+		QUERY_KEYS.Contracts.Synthetix.LastDebtLedgerEntry,
+		() => snxjs.contracts.SynthetixState.lastDebtLedgerEntry(),
+		{ ...options }
+	);
+};
+
+export const useTotalIssuedSynthsExcludeEtherCollateral = (
+	name: string,
+	options?: BaseQueryOptions
+) => {
+	const snxjs = useContext(SNXJSContext);
+	return useQuery<BigNumber, QueryKey<any>>(
+		QUERY_KEYS.Contracts.Synthetix.TotalIssuedSynthsExcludeEtherCollateral(name),
+		() => snxjs.contracts.Synthetix.totalIssuedSynthsExcludeEtherCollateral(snxjs.toBytes32(name)),
+		{ ...options }
+	);
+};
+
+export const useIssuanceRatio = (options?: BaseQueryOptions) => {
+	const snxjs = useContext(SNXJSContext);
+	return useQuery<BigNumber, QueryKey<any>>(
+		QUERY_KEYS.Contracts.SynthetixState.IssuanceRatio,
+		() => snxjs.contracts.SynthetixState.issuanceRatio(),
+		{ ...options }
+	);
+};
+
+export const useSynthSUSDTotalSupply = (options?: BaseQueryOptions) => {
+	const snxjs = useContext(SNXJSContext);
+	return useQuery<BigNumber, QueryKey<any>>(
+		QUERY_KEYS.Contracts.SynthsUSD.TotalSupply,
+		() => snxjs.contracts.SynthsUSD.totalSupply(),
+		{ ...options }
+	);
+};
+
+export const useTotalIssuedSynths = (options?: BaseQueryOptions) => {
+	const snxjs = useContext(SNXJSContext);
+	return useQuery<BigNumber, QueryKey<any>>(
+		QUERY_KEYS.Contracts.EtherCollateralsUSD.TotalIssuedSynths,
+		() => snxjs.contracts.EtherCollateralsUSD.totalIssuedSynths(),
+		{ ...options }
+	);
+};
+
+export const useMarketCap = (synth: string) => {
+	const snxjs = useContext(SNXJSContext);
+	const { formatEther } = snxjs.utils;
+
+	return useQueryGroup(
+		[useRateForCurrency(synth), useTotalSupply()],
+		(unformattedPrice, unformattedSnxTotalSupply) => {
+			const price = Number(formatEther(unformattedPrice));
+			const totalSupply = Number(formatEther(unformattedSnxTotalSupply));
+			const marketCap = totalSupply * price;
+			return marketCap;
+		}
+	);
+};
+
+export const useTotalSNXLocked = () => {
+	const snxjs = useContext(SNXJSContext);
+	const { formatEther } = snxjs.utils;
+	const networkMetaQuery = useSNXNetworkMeta();
+	return useQueryGroup(
+		[useRateForCurrency('SNX'), useTotalSupply()],
+		(unformattedSnxPrice, unformattedSnxTotalSupply) => {
+			const { snxLocked, snxTotal } = networkMetaQuery.data;
+			const percentLocked = snxLocked / snxTotal;
+			const totalSupplySNX = Number(formatEther(unformattedSnxTotalSupply));
+			const priceSNX = Number(formatEther(unformattedSnxPrice));
+
+			const totalSNXLocked = percentLocked * totalSupplySNX * priceSNX;
+			return totalSNXLocked;
+		},
+		{ enabled: networkMetaQuery.data }
+	);
+};
+
+export const useNetworkCRatio = () => {
+	const snxjs = useContext(SNXJSContext);
+	const { formatEther } = snxjs.utils;
+
+	return useQueryGroup(
+		[
+			useTotalSupply(),
+			useRateForCurrency('SNX'),
+			useTotalIssuedSynthsExcludeEtherCollateral('sUSD'),
+		],
+		(unformattedSnxTotalSupply, unformattedSnxPrice, unformattedTotalIssuedSynths) => {
+			const totalSupply = Number(formatEther(unformattedSnxTotalSupply));
+			const formattedSNXPrice = Number(formatEther(unformattedSnxPrice));
+			const totalIssuedSynths = Number(formatEther(unformattedTotalIssuedSynths));
+
+			const networkCRatio = (totalSupply * formattedSNXPrice) / totalIssuedSynths;
+			return networkCRatio;
+		}
+	);
+};
+
+export const useSNXPriceChart = (period: ChartPeriod) =>
+	useQueryGroup(
+		[useChartData(period), useRateForCurrency('SNX')],
+		(chartData, snxPrice) => {
+			const priorSNXPrice = chartData[0].averagePrice;
+			const percentChange = snxPrice / priorSNXPrice - 1;
+			return { chartData, snxPrice, priorSNXPrice, percentChange };
+		},
+		{
+			initialData: {
+				chartData: [],
+				snxPrice: null,
+				priorSNXPrice: null,
+				percentChange: null,
+			},
+		}
+	);

--- a/queries/useQueryGroup.ts
+++ b/queries/useQueryGroup.ts
@@ -1,0 +1,42 @@
+import { QueryResult, QueryStatus } from 'react-query';
+import Options from 'sections/Options';
+
+export const useQueryGroup = (
+	queries: QueryResult<any>[],
+	onDataReady: (...args: any) => any,
+	options: { enabled?: boolean; initialData?: Object } = { enabled: true, initialData: undefined }
+) => ({
+	isLoading: isLoadingAny(queries),
+	isSuccess: isSuccessAll(queries),
+	isError: isErrorAny(queries),
+	isIdle: isIdleAll(queries),
+	refetch: () => refetchAll(queries),
+	data:
+		hasDataAll(queries) && options.enabled
+			? onDataReady(...queries.map((query) => query.data))
+			: options.initialData,
+	error: getMostRecentError(queries),
+});
+
+const getMostRecentError = (queries: QueryResult<any>[]) =>
+	isErrorAny(queries) ? queries.find((query) => query.error) : null;
+
+const isLoadingAny = (queries: QueryResult<any>[]) =>
+	queries.reduce((arr, cur) => arr || cur.isLoading, false);
+
+const isErrorAny = (queries: QueryResult<any>[]) =>
+	queries.reduce((arr, cur) => arr || cur.isError, false);
+
+const isSuccessAll = (queries: QueryResult<any>[]) =>
+	queries.reduce((arr, cur) => arr && cur.isSuccess, true);
+
+const isIdleAll = (queries: QueryResult<any>[]) =>
+	queries.reduce((arr, cur) => arr && cur.isIdle, true);
+
+const hasDataAll = (queries: QueryResult<any>[]) =>
+	queries.reduce((acc, cur) => acc && cur.data !== undefined, true);
+
+const refetchAll = (queries: QueryResult<any>[]) =>
+	Promise.all(queries.map((query) => query.refetch({ throwOnError: true })));
+
+export default useQueryGroup;

--- a/queries/wallet.ts
+++ b/queries/wallet.ts
@@ -1,0 +1,26 @@
+import QUERY_KEYS from 'constants/queryKeys';
+import { BigNumber } from 'ethers';
+import { ProviderContext, SNXJSContext } from 'pages/_app';
+import { useContext } from 'react';
+import { BaseQueryOptions, QueryKey, useQuery } from 'react-query';
+import useQueryGroup from './useQueryGroup';
+
+export const useWalletBalance = (address: string, options?: BaseQueryOptions) => {
+	const provider = useContext(ProviderContext);
+	return useQuery<BigNumber, QueryKey<any>>(
+		QUERY_KEYS.Wallet.Balance(address),
+		() => provider.getBalance(address),
+		{ ...options }
+	);
+};
+
+export const useEtherLocked = () => {
+	const snxjs = useContext(SNXJSContext);
+	return useQueryGroup(
+		[
+			useWalletBalance(snxjs.contracts.EtherCollateralsUSD.address),
+			useWalletBalance(snxjs.contracts.EtherCollateral.address),
+		],
+		(ethUSD, ETH) => ethUSD + ETH
+	);
+};


### PR DESCRIPTION
So each stat box will get its own hook:
```
export const useMarketCap = (synth: string) => {
	const snxjs = useContext(SNXJSContext);
	const { formatEther } = snxjs.utils;

	const queryCache = useQueryCache();
	const refetch = () =>
		queryCache.invalidateQueries(
			[
				QUERY_KEYS.Contracts.ExchangeRates.RateForCurrency(synth),
				QUERY_KEYS.Contracts.Synthetix.TotalSupply,
			],
			{
				exact: true,
				throwOnError: true,
				refetchActive: true,
				refetchInactive: false,
			}
		);

	const unformattedPriceQuery = useRateForCurrency(synth);
	const unformattedSnxTotalSupplyQuery = useTotalSupply();

	const price = unformattedPriceQuery.data ? Number(formatEther(unformattedPriceQuery.data)) : null;
	const totalSupply = unformattedSnxTotalSupplyQuery.data
		? Number(formatEther(unformattedSnxTotalSupplyQuery.data))
		: null;
	const marketCap = price != null && totalSupply != null ? totalSupply * (price ?? 0) : null;

	return {
		marketCap,
		isLoading: unformattedPriceQuery.isLoading && unformattedSnxTotalSupplyQuery.isLoading,
		isError: unformattedPriceQuery.isError && unformattedSnxTotalSupplyQuery.isError,
		refetch,
	};
};
```
And we'll wrap the StatBoxes in `<Retry/>`:
```
const {
		marketCap: snxMarketCap,
		isError: isMarketCapError,
		refetch: refetchMarketCap,
	} = useMarketCap('SNX');

return <Retry isError={isMarketCapError} onRefetch={refetchMarketCap}><StatsBox/></Retry>
```

`react-query` will ensure:

- We only request each query once
- We only retry failed queries one time.
- Dependent queries update when one of their children updates
- Granular cache invalidation, we can invalidate everything, some things, or one thing. 