### PR TITLE
small fixes for react-query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1408,50 +1408,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@chainlink/contracts-0.0.10": {
-			"version": "npm:@chainlink/contracts@0.0.10",
-			"resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
-			"integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
-			"requires": {
-				"@truffle/contract": "^4.2.6",
-				"ethers": "^4.0.45"
-			},
-			"dependencies": {
-				"ethers": {
-					"version": "4.0.48",
-					"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
-					"integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
-					"optional": true,
-					"requires": {
-						"aes-js": "3.0.0",
-						"bn.js": "^4.4.0",
-						"elliptic": "6.5.3",
-						"hash.js": "1.1.3",
-						"js-sha3": "0.5.7",
-						"scrypt-js": "2.0.4",
-						"setimmediate": "1.0.4",
-						"uuid": "2.0.1",
-						"xmlhttprequest": "1.8.0"
-					}
-				},
-				"hash.js": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-					"optional": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"minimalistic-assert": "^1.0.0"
-					}
-				},
-				"scrypt-js": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-					"integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
-					"optional": true
-				}
-			}
-		},
 		"@chaitanyapotti/random-id": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@chaitanyapotti/random-id/-/random-id-1.0.3.tgz",
@@ -5572,6 +5528,11 @@
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
 			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
 		},
+		"big-integer": {
+			"version": "1.6.48",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+		},
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -5768,6 +5729,27 @@
 			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 			"requires": {
 				"fill-range": "^7.0.1"
+			}
+		},
+		"broadcast-channel": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.4.1.tgz",
+			"integrity": "sha512-VXYivSkuBeQY+pL5hNQQNvBdKKQINBAROm4G8lAbWQfOZ7Yn4TMcgLNlJyEqlkxy5G8JJBsI3VJ1u8FUTOROcg==",
+			"requires": {
+				"@babel/runtime": "^7.7.2",
+				"detect-node": "^2.0.4",
+				"js-sha3": "0.8.0",
+				"microseconds": "0.2.0",
+				"nano-time": "1.0.0",
+				"rimraf": "3.0.2",
+				"unload": "2.2.0"
+			},
+			"dependencies": {
+				"js-sha3": {
+					"version": "0.8.0",
+					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+				}
 			}
 		},
 		"brorand": {
@@ -7383,6 +7365,11 @@
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 			"optional": true
+		},
+		"detect-node": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -12717,16 +12704,6 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"match-sorter": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-4.2.1.tgz",
-			"integrity": "sha512-s+3h9TiZU9U1pWhIERHf8/f4LmBN6IXaRgo2CI17+XGByGS1GvG5VvXK9pcGyCjGe3WM3mSYRC3ipGrd5UEVgw==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.10.5",
-				"remove-accents": "0.4.2"
-			}
-		},
 		"matchmediaquery": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
@@ -13010,6 +12987,11 @@
 					}
 				}
 			}
+		},
+		"microseconds": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+			"integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
 		},
 		"miller-rabin": {
 			"version": "4.0.1",
@@ -13345,6 +13327,14 @@
 			"resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
 			"integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
 			"optional": true
+		},
+		"nano-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+			"integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+			"requires": {
+				"big-integer": "^1.6.16"
+			}
 		},
 		"nanoid": {
 			"version": "3.1.16",
@@ -14129,11 +14119,6 @@
 			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
 			"integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
 			"dev": true
-		},
-		"openzeppelin-solidity-2.3.0": {
-			"version": "npm:openzeppelin-solidity@2.3.0",
-			"resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-			"integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
 		},
 		"optionator": {
 			"version": "0.8.3",
@@ -15093,20 +15078,24 @@
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-query": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/react-query/-/react-query-2.23.0.tgz",
-			"integrity": "sha512-LHBhrr7ntstjpt85ssEaW3cGJx4BqQBFleTM3fXMO0MFzaMDQx0oxdUur+iQSOpLGPlrpToJbrjFNMQTpEExdA==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/react-query/-/react-query-3.12.1.tgz",
+			"integrity": "sha512-NdO1yucDM2ic4JkK46qgGjGggtHjT/R7I7gCChTllYHvZn2DVtIGwH6P1UVtGZVLgL7hn5Eq3Cw7eDbMija5uA==",
 			"requires": {
-				"@babel/runtime": "^7.5.5"
-			}
-		},
-		"react-query-devtools": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/react-query-devtools/-/react-query-devtools-2.5.1.tgz",
-			"integrity": "sha512-9d5lQFb3jrQ+8Bu53VUu7P2xJdgie9z494JPph5G04ETijGBkyYk2TVS3RGSupsRA1geXaSaAhICU+Sn2ru9tg==",
-			"dev": true,
-			"requires": {
-				"match-sorter": "^4.1.0"
+				"@babel/runtime": "^7.5.5",
+				"broadcast-channel": "^3.4.1",
+				"match-sorter": "^6.0.2"
+			},
+			"dependencies": {
+				"match-sorter": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz",
+					"integrity": "sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==",
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"remove-accents": "0.4.2"
+					}
+				}
 			}
 		},
 		"react-refresh": {
@@ -15370,8 +15359,7 @@
 		"remove-accents": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-			"integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=",
-			"dev": true
+			"integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -17363,10 +17351,57 @@
 				"web3-utils": "1.2.2"
 			},
 			"dependencies": {
+				"@chainlink/contracts-0.0.10": {
+					"version": "npm:@chainlink/contracts@0.0.10",
+					"resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
+					"integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
+					"requires": {
+						"@truffle/contract": "^4.2.6",
+						"ethers": "^4.0.45"
+					}
+				},
 				"bn.js": {
 					"version": "4.11.8",
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
 					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+				},
+				"ethers": {
+					"version": "4.0.48",
+					"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+					"integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+					"optional": true,
+					"requires": {
+						"aes-js": "3.0.0",
+						"bn.js": "^4.4.0",
+						"elliptic": "6.5.3",
+						"hash.js": "1.1.3",
+						"js-sha3": "0.5.7",
+						"scrypt-js": "2.0.4",
+						"setimmediate": "1.0.4",
+						"uuid": "2.0.1",
+						"xmlhttprequest": "1.8.0"
+					}
+				},
+				"hash.js": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+					"optional": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.0"
+					}
+				},
+				"openzeppelin-solidity-2.3.0": {
+					"version": "npm:openzeppelin-solidity@2.3.0",
+					"resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+					"integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
+				},
+				"scrypt-js": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+					"integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+					"optional": true
 				},
 				"web3-utils": {
 					"version": "1.2.2",
@@ -18149,6 +18184,15 @@
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"optional": true
+		},
+		"unload": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+			"integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"detect-node": "^2.0.4"
+			}
 		},
 		"unpipe": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"react": "16.13.1",
 		"react-dom": "16.13.1",
 		"react-i18next": "11.7.0",
-		"react-query": "2.23.0",
+		"react-query": "3.12.1",
 		"react-responsive": "8.1.0",
 		"react-select": "3.1.0",
 		"react-table": "7.5.0",
@@ -65,7 +65,6 @@
 		"husky": "4.2.3",
 		"lint-staged": "10.0.10",
 		"prettier": "2.0.5",
-		"react-query-devtools": "2.5.1",
 		"svg-react-loader": "0.4.6",
 		"typescript": "3.9.7"
 	},

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,8 +2,8 @@ import { createContext, FC, createRef, RefObject } from 'react';
 import { AppProps } from 'next/app';
 import Head from 'next/head';
 import { ethers } from 'ethers';
-import { ReactQueryCacheProvider, QueryCache } from 'react-query';
-import { ReactQueryDevtools } from 'react-query-devtools';
+import { QueryClientProvider, QueryClient } from 'react-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
 
 import { synthetix, Network } from '@synthetixio/js';
 import { ThemeProvider as SCThemeProvider } from 'styled-components';
@@ -33,11 +33,11 @@ export const ProviderContext = createContext(provider);
 
 export const HeadersContext = createContext(headersAndScrollRef);
 
-const queryCache = new QueryCache({
-	defaultConfig: {
+const queryClient = new QueryClient({
+	defaultOptions: {
 		queries: {
-			retry: 1,
-			cacheTime: Infinity,
+			retry: 0, // on failure, do not repeat the request
+			refetchInterval: 60000, // reloads query data automatically every minute
 		},
 	},
 });
@@ -124,7 +124,7 @@ const App: FC<AppProps> = ({ Component, pageProps }) => {
 			</Head>
 			<SCThemeProvider theme={scTheme}>
 				<MuiThemeProvider theme={muiTheme}>
-					<ReactQueryCacheProvider queryCache={queryCache}>
+					<QueryClientProvider client={queryClient}>
 						<HeadersContext.Provider value={headersAndScrollRef}>
 							<SNXJSContext.Provider value={snxjs}>
 								<ProviderContext.Provider value={provider}>
@@ -135,7 +135,7 @@ const App: FC<AppProps> = ({ Component, pageProps }) => {
 							</SNXJSContext.Provider>
 						</HeadersContext.Provider>
 						<ReactQueryDevtools />
-					</ReactQueryCacheProvider>
+					</QueryClientProvider>
 				</MuiThemeProvider>
 			</SCThemeProvider>
 		</>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -37,7 +37,8 @@ const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			retry: 0, // on failure, do not repeat the request
-			refetchInterval: 60000, // reloads query data automatically every minute
+			refetchOnWindowFocus: false,
+			refetchOnReconnect: false,
 		},
 	},
 });

--- a/sections/YieldFarming/index.tsx
+++ b/sections/YieldFarming/index.tsx
@@ -18,7 +18,7 @@ import { useSnxjsContractQuery } from 'queries/shared/useSnxjsContractQuery';
 import { useCMCQuery } from 'queries/shared/useCMCQuery';
 
 import QUERY_KEYS from 'constants/queryKeys';
-import { QueryResult, useQuery } from 'react-query';
+import { UseQueryResult, useQuery } from 'react-query';
 import {
 	RewardsContractInfo,
 	useRewardsContractInfo,
@@ -56,7 +56,7 @@ const YieldFarming: FC = () => {
 
 	const curveContractInfo = useCurveContractInfoQuery(provider);
 
-	const rewardsData: { [id: string]: QueryResult<RewardsContractInfo, string> } = {
+	const rewardsData: { [id: string]: UseQueryResult<RewardsContractInfo, string> } = {
 		CURVE_SUSD: useRewardsContractInfo(provider, curvepoolRewards.address, true),
 		iETH: useRewardsContractInfo(provider, snxjs.contracts.StakingRewardsiETH.address, false),
 		iBTC: useRewardsContractInfo(provider, snxjs.contracts.StakingRewardsiBTC.address, false),


### PR DESCRIPTION
* upgrade react-query (and devtools) to v3 line
* update `QueryClient` configuration to retry 0 and test to ensure it works
* add `refetchInterval` option to automatically reload dashboard data on an interval

because stale is set to "0" by default, if any new views mount, the data will be unconditionally refreshed automatically as well.

upon running `npm i`, some `package-lock.json` changes were added outside of react query. let me know if these should be undone.

/hours 1