### PR TITLE
pull SNXHolders query directly without snxData

### DIFF
--- a/constants/graph-urls.ts
+++ b/constants/graph-urls.ts
@@ -1,4 +1,5 @@
 export const aave = 'https://api.thegraph.com/subgraphs/name/aave/protocol-multy-raw';
 export const uniswapV2 = 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2';
+export const synthetixSnx = 'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix';
 export const synthetixExchanges =
 	'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-exchanges';

--- a/sections/Staking/index.tsx
+++ b/sections/Staking/index.tsx
@@ -69,7 +69,10 @@ const Staking: FC = () => {
 	);
 
 	const stakingPeriods: ChartPeriod[] = ['W', 'M', 'Y'];
-	const SNXValueStaked = useMemo(() => (SNXPrice ?? 0) * (SNXStaked ?? 0), [SNXPrice, SNXStaked]);
+	const SNXValueStaked = useMemo(() => (SNXPrice && SNXStaked ? SNXPrice * SNXStaked : null), [
+		SNXPrice,
+		SNXStaked,
+	]);
 
 	return (
 		<>


### PR DESCRIPTION
there is an error on subgraph API which prevents collection of accurate
SNXHolders data. So use custom query for the time being to preserve accuracy in the meantime instead.