### PR TITLE
fix calculation of SNXStaked, and correct staking APY metrics

### DIFF
--- a/queries/shared/useSNXInfo.ts
+++ b/queries/shared/useSNXInfo.ts
@@ -93,10 +93,17 @@ export const useSNXInfo = (snxjs: SynthetixJS) => {
 		}
 	}
 
+	const SNXPrice = unformattedSnxPrice.isSuccess
+		? Number(formatEther(unformattedSnxPrice.data!))
+		: null;
+
 	return {
-		SNXPrice: unformattedSnxPrice.isSuccess ? Number(formatEther(unformattedSnxPrice.data!)) : null,
+		SNXPrice,
 		SNXTotalSupply,
-		SNXStaked: SNXTotalSupply && snxTotal ? (SNXTotalSupply * snxLocked) / snxTotal : null,
+		SNXStaked:
+			SNXPrice && totalIssuedSynths && tempIssuanceRatio
+				? totalIssuedSynths / tempIssuanceRatio / SNXPrice
+				: null,
 		SNXPercentLocked: snxTotal ? snxLocked / snxTotal : null,
 		issuanceRatio: tempIssuanceRatio,
 		activeCRatio: stakersTotalDebt ? stakersTotalCollateral / stakersTotalDebt : null,

--- a/sections/Staking/index.tsx
+++ b/sections/Staking/index.tsx
@@ -90,8 +90,6 @@ const Staking: FC = () => {
 
 		stakeApySnx = (snxThisWeek * (365.0 / 7)) / fakeSnxStaked;
 		stakeApyFees = (usdThisWeek * (365.0 / 7)) / (SNXPrice * fakeSnxStaked);
-
-		console.log(stakeApySnx, stakeApyFees);
 	}
 
 	return (


### PR DESCRIPTION
SNXStaked is just a function of total issued synths, issuanceRatio, and snx price.

To make the calculation for APY metrics as clear as possible, the calculation supposes
a fake user with 1000 SNX staked, calculating their rewards and APY from there.

/hours 2