### PR TITLE
add rewards shorting info

### DIFF
--- a/queries/yield-farming/useRewardsContractInfoQuery.ts
+++ b/queries/yield-farming/useRewardsContractInfoQuery.ts
@@ -3,43 +3,114 @@ import { useQuery } from 'react-query';
 import QUERY_KEYS from 'constants/queryKeys';
 import { ethers } from 'ethers';
 import { curvepoolRewards, snxRewards } from 'contracts';
+import { useSnxjsContractQuery } from 'queries/shared/useSnxjsContractQuery';
+import { SynthetixJS } from '@synthetixio/js';
+import { useCMCQuery } from 'queries/shared/useCMCQuery';
+import axios from 'axios';
+import { useCurveContractInfoQuery } from './useCurveContractInfoQuery';
 
 export interface RewardsContractInfo {
 	duration: number;
 	rate: number;
+	totalSupply: number;
 	periodFinish: number;
 }
 
+export interface RewardsData {
+	price: number | null;
+	apy: number | null;
+	distribution: number | null;
+	rewardsInfo: RewardsContractInfo | null;
+}
+
 export const useRewardsContractInfo = (
+	snxjs: SynthetixJS,
 	provider: ethers.providers.Provider,
+	fromToken: string,
 	contractAddress: string,
-	isCurve: boolean
+	type: 'shorting' | 'staking' | 'curve'
 ) => {
 	const rewardsContract = new ethers.Contract(
 		contractAddress,
-		isCurve ? curvepoolRewards.abi : snxRewards.abi,
+		type === 'curve' ? curvepoolRewards.abi : snxRewards.abi,
 		provider
 	);
 
-	return useQuery<RewardsContractInfo, string>(
+	const rewardsInfo = useQuery<RewardsContractInfo, string>(
 		QUERY_KEYS.YieldFarming.RewardsInfo(contractAddress),
 		async () => {
 			const rawRewardsContractInfo = await Promise.all([
 				rewardsContract.DURATION ? rewardsContract.DURATION() : rewardsContract.rewardsDuration(),
 				rewardsContract.rewardRate(),
+				rewardsContract.totalSupply(),
 				rewardsContract.periodFinish(),
 			]);
 
-			let [duration, rate, periodFinish] = rawRewardsContractInfo.map((d) =>
-				Number(ethers.utils.formatEther(d))
-			);
-			periodFinish = rawRewardsContractInfo[2].toNumber();
-
 			return {
-				duration,
-				rate,
-				periodFinish,
+				duration: rawRewardsContractInfo[0].toNumber(),
+				rate: Number(ethers.utils.formatEther(rawRewardsContractInfo[1])),
+				totalSupply: Number(ethers.utils.formatEther(rawRewardsContractInfo[2])),
+				periodFinish: rawRewardsContractInfo[3].toNumber(),
 			};
 		}
 	);
+
+	const price = useSnxjsContractQuery<ethers.BigNumber>(snxjs, 'ExchangeRates', 'rateForCurrency', [
+		snxjs.toBytes32(fromToken),
+	]);
+
+	const SNXPrice = useSnxjsContractQuery<ethers.BigNumber>(
+		snxjs,
+		'ExchangeRates',
+		'rateForCurrency',
+		[snxjs.toBytes32('SNX')]
+	);
+
+	let distribution = null;
+	if (rewardsInfo.isSuccess) {
+		const d = rewardsInfo.data;
+		const durationInWeeks = d.duration / (3600 * 24 * 7);
+		const isPeriodFinished = new Date().getTime() > Number(d.periodFinish) * 1000;
+
+		distribution = isPeriodFinished ? 0 : (d.duration * d.rate) / durationInWeeks;
+	}
+
+	let apy = 0;
+
+	if (rewardsInfo.isSuccess && price.isSuccess && SNXPrice.isSuccess) {
+		apy =
+			(rewardsInfo.data.rate *
+				(365 * 24 * 60 * 60) *
+				Number(ethers.utils.formatEther(SNXPrice.data))) /
+			rewardsInfo.data.totalSupply /
+			Number(ethers.utils.formatEther(price.data!));
+	}
+
+	if (type === 'curve') {
+		/* eslint-disable react-hooks/rules-of-hooks */
+		const curveContractInfo = useCurveContractInfoQuery(provider);
+		const crvPriceInfo = useCMCQuery('CRV');
+		const curveApy = useQuery<any, string>(QUERY_KEYS.YieldFarming.CurveApy, async () => {
+			return (await axios.get('https://www.curve.fi/raw-stats/apys.json')).data;
+		});
+
+		if (curveContractInfo.isSuccess) {
+			const d = curveContractInfo.data!;
+
+			const curveSUSDTokenRate =
+				(((d.curveInflationRate * d.gaugeRelativeWeight * 31536000) / d.curveWorkingSupply) * 0.4) /
+				d.curveSusdTokenPrice;
+
+			apy += crvPriceInfo.isSuccess ? crvPriceInfo.data!.quote.USD.price * curveSUSDTokenRate : 0;
+		}
+
+		apy += curveApy?.data?.apy?.day?.susd || 0;
+	}
+
+	return {
+		price: price.isSuccess ? Number(ethers.utils.formatEther(price.data!)) : null,
+		rewardsInfo: rewardsInfo.data,
+		distribution,
+		apy: apy || null,
+	};
 };

--- a/sections/YieldFarming/index.tsx
+++ b/sections/YieldFarming/index.tsx
@@ -112,16 +112,7 @@ const YieldFarming: FC = () => {
 						firstMetric={d[1].distribution}
 						firstColor={COLORS.green}
 						secondMetricTitle={t('iETH.secondMetricTitle')}
-						secondMetric={
-							d[1].distribution != null &&
-							d[1].rewardsInfo != null &&
-							d[1].price != null &&
-							SNXPrice != null
-								? d[1].apy /*((d[1].distribution * SNXPrice) /
-									(d[1].balance * d[1].price))*/
-								: //52
-								  null
-						}
+						secondMetric={d[1].apy}
 						secondColor={COLORS.green}
 						secondMetricStyle="percent2"
 					/>

--- a/sections/YieldFarming/index.tsx
+++ b/sections/YieldFarming/index.tsx
@@ -1,6 +1,4 @@
-import { ethers } from 'ethers';
 import { FC, useContext } from 'react';
-import axios from 'axios';
 import { useTranslation, Trans } from 'react-i18next';
 
 import SectionHeader from 'components/SectionHeader';
@@ -10,20 +8,9 @@ import DoubleStatsBox from 'components/DoubleStatsBox';
 
 import { COLORS } from 'constants/styles';
 import { SNXJSContext, ProviderContext } from 'pages/_app';
-import { formatPercentage } from 'utils/formatter';
-import { FullLineText } from '../../components/common';
 import { useSNXInfo } from 'queries/shared/useSNXInfo';
-import { useTokenBalanceQuery } from 'queries/shared/useTokenBalanceQuery';
-import { useSnxjsContractQuery } from 'queries/shared/useSnxjsContractQuery';
-import { useCMCQuery } from 'queries/shared/useCMCQuery';
 
-import QUERY_KEYS from 'constants/queryKeys';
-import { UseQueryResult, useQuery } from 'react-query';
-import {
-	RewardsContractInfo,
-	useRewardsContractInfo,
-	useCurveContractInfoQuery,
-} from 'queries/yield-farming';
+import { useRewardsContractInfo, RewardsData } from 'queries/yield-farming';
 import { curvepoolRewards } from 'contracts';
 import { usePageResults } from 'queries/shared/usePageResults';
 import { aave } from 'constants/graph-urls';
@@ -54,37 +41,36 @@ const YieldFarming: FC = () => {
 
 	const provider = useContext(ProviderContext);
 
-	const curveContractInfo = useCurveContractInfoQuery(provider);
-
-	const rewardsData: { [id: string]: UseQueryResult<RewardsContractInfo, string> } = {
-		CURVE_SUSD: useRewardsContractInfo(provider, curvepoolRewards.address, true),
-		iETH: useRewardsContractInfo(provider, snxjs.contracts.StakingRewardsiETH.address, false),
-		iBTC: useRewardsContractInfo(provider, snxjs.contracts.StakingRewardsiBTC.address, false),
+	const rewardsData: { [id: string]: any } = {
+		'curve-susd': useRewardsContractInfo(
+			snxjs,
+			provider,
+			'sUSD',
+			curvepoolRewards.address,
+			'curve'
+		),
+		ShortsETH: useRewardsContractInfo(
+			snxjs,
+			provider,
+			'sETH',
+			snxjs.contracts.ShortingRewardssETH.address,
+			'shorting'
+		),
+		ShortsBTC: useRewardsContractInfo(
+			snxjs,
+			provider,
+			'sBTC',
+			snxjs.contracts.ShortingRewardssBTC.address,
+			'shorting'
+		),
+		iETH: useRewardsContractInfo(
+			snxjs,
+			provider,
+			'iETH',
+			snxjs.contracts.StakingRewardsiETH.address,
+			'staking'
+		),
 	};
-
-	const iEthBalance = useTokenBalanceQuery(
-		provider,
-		snxjs.contracts.ProxyiETH.address,
-		snxjs.contracts.StakingRewardsiETH.address
-	);
-	const iBtcBalance = useTokenBalanceQuery(
-		provider,
-		snxjs.contracts.ProxyiBTC.address,
-		snxjs.contracts.StakingRewardsiBTC.address
-	);
-
-	const iEthPrice = useSnxjsContractQuery<ethers.BigNumber>(
-		snxjs,
-		'ExchangeRates',
-		'rateForCurrency',
-		[snxjs.toBytes32('iETH')]
-	);
-	const iBtcPrice = useSnxjsContractQuery<ethers.BigNumber>(
-		snxjs,
-		'ExchangeRates',
-		'rateForCurrency',
-		[snxjs.toBytes32('iBTC')]
-	);
 
 	const aaveDepositInfo = usePageResults<any[]>({
 		api: aave,
@@ -101,42 +87,6 @@ const YieldFarming: FC = () => {
 		max: 1,
 	});
 
-	const crvPriceInfo = useCMCQuery('CRV');
-
-	const curveApy = useQuery<any, string>(QUERY_KEYS.YieldFarming.CurveApy, async () => {
-		return (await axios.get('https://www.curve.fi/raw-stats/apys.json')).data;
-	});
-
-	const distributions: { [id: string]: number | null } = {};
-	for (const r in rewardsData) {
-		if (!rewardsData[r].isSuccess) {
-			distributions[r] = null;
-			continue;
-		}
-
-		const d = rewardsData[r].data!;
-
-		const durationInWeeks = d.duration / (3600 * 24 * 7);
-		const isPeriodFinished = new Date().getTime() > Number(d.periodFinish) * 1000;
-
-		distributions[r] = isPeriodFinished ? 0 : (d.duration * d.rate) / durationInWeeks;
-	}
-
-	let curveTokenAPY: number | null = null;
-	if (curveContractInfo.isSuccess) {
-		const d = curveContractInfo.data!;
-
-		const curveSUSDTokenRate =
-			(((d.curveInflationRate * d.gaugeRelativeWeight * 31536000) / d.curveWorkingSupply) * 0.4) /
-			d.curveSusdTokenPrice;
-
-		curveTokenAPY = crvPriceInfo.isSuccess
-			? crvPriceInfo.data!.quote.USD.price * curveSUSDTokenRate
-			: null;
-	}
-
-	const curveSwapAPY = curveApy?.data?.apy?.day?.susd || null;
-
 	const aaveDepositRate = aaveDepositInfo.isSuccess
 		? Number(aaveDepositInfo.data![0].liquidityRate) / 1e27
 		: null;
@@ -152,99 +102,30 @@ const YieldFarming: FC = () => {
 				numberStyle="percent2"
 			/>
 			<StatsRow>
-				<DoubleStatsBox
-					key="CRVSUSDRWRDS"
-					title={t('curve-susd.title')}
-					subtitle={<SubtitleText name="sUSD" />}
-					firstMetricTitle={t('curve-susd.firstMetricTitle')}
-					firstMetricStyle="number"
-					firstMetric={distributions['CURVE_SUSD']}
-					firstColor={COLORS.pink}
-					secondMetricTitle={t('curve-susd.secondMetricTitle')}
-					secondMetric={
-						SNXPrice != null &&
-						distributions['CURVE_SUSD'] != null &&
-						curveContractInfo.isSuccess &&
-						curveSwapAPY != null &&
-						curveTokenAPY != null
-							? ((distributions['CURVE_SUSD'] * (SNXPrice ?? 0)) /
-									(curveContractInfo.data!.curveSusdBalance *
-										curveContractInfo.data!.curveSusdTokenPrice)) *
-									52 +
-							  curveSwapAPY +
-							  curveTokenAPY
-							: null
-					}
-					secondColor={COLORS.green}
-					secondMetricStyle="percent2"
-					infoData={
-						<Trans
-							i18nKey={'curve-susd.infoData'}
-							values={{
-								rewards: curveTokenAPY != null ? formatPercentage(curveTokenAPY) : '...',
-								snxRewards:
-									distributions['CURVE_SUSD'] != null &&
-									curveContractInfo.isSuccess &&
-									SNXPrice != null
-										? formatPercentage(
-												((distributions['CURVE_SUSD'] * (SNXPrice ?? 0)) /
-													(curveContractInfo.data!.curveSusdBalance *
-														curveContractInfo.data!.curveSusdTokenPrice)) *
-													52
-										  )
-										: '...',
-								swapFees: curveSwapAPY != null ? formatPercentage(curveSwapAPY) : '...',
-							}}
-							components={{
-								fullLineText: <FullLineText />,
-							}}
-						/>
-					}
-				/>
-				<DoubleStatsBox
-					key="iETHRWRDS"
-					title={t('iETH.title')}
-					subtitle={<SubtitleText name="iETH" />}
-					firstMetricTitle={t('iETH.firstMetricTitle')}
-					firstMetricStyle="number"
-					firstMetric={distributions['iETH']}
-					firstColor={COLORS.green}
-					secondMetricTitle={t('iETH.secondMetricTitle')}
-					secondMetric={
-						distributions['iETH'] != null &&
-						iEthBalance.isSuccess &&
-						iEthPrice.isSuccess &&
-						SNXPrice != null
-							? ((distributions['iETH'] * (SNXPrice ?? 0)) /
-									(Number(iEthBalance.data!) * Number(ethers.utils.formatEther(iEthPrice.data!)))) *
-							  52
-							: null
-					}
-					secondColor={COLORS.green}
-					secondMetricStyle="percent2"
-				/>
-				<DoubleStatsBox
-					key="iBTCRWRDS"
-					title={t('iBTC.title')}
-					subtitle={<SubtitleText name="iBTC" />}
-					firstMetricTitle={t('iBTC.firstMetricTitle')}
-					firstMetricStyle="number"
-					firstMetric={distributions['iBTC']}
-					firstColor={COLORS.green}
-					secondMetricTitle={t('iBTC.secondMetricTitle')}
-					secondMetric={
-						distributions['iBTC'] != null &&
-						iBtcBalance.isSuccess &&
-						iBtcPrice.isSuccess &&
-						SNXPrice != null
-							? ((distributions['iBTC'] * (SNXPrice ?? 0)) /
-									(Number(iBtcBalance.data!) * Number(ethers.utils.formatEther(iBtcPrice.data!)))) *
-							  52
-							: null
-					}
-					secondColor={COLORS.green}
-					secondMetricStyle="percent2"
-				/>
+				{Object.entries(rewardsData).map((d: [string, RewardsData]) => (
+					<DoubleStatsBox
+						key={d[0] + 'RWRDS'}
+						title={t(d[0] + '.title')}
+						subtitle={<SubtitleText name={d[0]} />}
+						firstMetricTitle={t(d[0] + '.firstMetricTitle')}
+						firstMetricStyle="number"
+						firstMetric={d[1].distribution}
+						firstColor={COLORS.green}
+						secondMetricTitle={t('iETH.secondMetricTitle')}
+						secondMetric={
+							d[1].distribution != null &&
+							d[1].rewardsInfo != null &&
+							d[1].price != null &&
+							SNXPrice != null
+								? d[1].apy /*((d[1].distribution * SNXPrice) /
+									(d[1].balance * d[1].price))*/
+								: //52
+								  null
+						}
+						secondColor={COLORS.green}
+						secondMetricStyle="percent2"
+					/>
+				))}
 			</StatsRow>
 		</>
 	);

--- a/translations/en.json
+++ b/translations/en.json
@@ -225,8 +225,13 @@
 		"firstMetricTitle": "WEEKLY REWARDS (SNX)",
 		"secondMetricTitle": "Annual Percentage Yield"
 	},
-	"iBTC": {
-		"title": "iBTC",
+	"ShortsETH": {
+		"title": "Short sETH",
+		"firstMetricTitle": "WEEKLY REWARDS (SNX)",
+		"secondMetricTitle": "Annual Percentage Yield"
+	},
+	"ShortsBTC": {
+		"title": "Short sBTC",
 		"firstMetricTitle": "WEEKLY REWARDS (SNX)",
 		"secondMetricTitle": "Annual Percentage Yield"
 	},


### PR DESCRIPTION
also includes a minor refacting of the rewards contract info so that it can just be mapped from the `useRewardsContractInfoQuery` hook

/hours 3