### PR TITLE
fixes for debt pool related statistics

### DIFF
--- a/components/Charts/CustomLegend.tsx
+++ b/components/Charts/CustomLegend.tsx
@@ -35,11 +35,10 @@ export default CustomLegend;
 const CustomLegendContainer = styled.div<{ isShortLegend: boolean }>`
 	display: flex;
 	flex-direction: column;
-	border: 1px solid ${colors.linedBlue};
 	width: 80%;
 	margin: 0 auto;
 	font-family: 'Inter', sans-serif;
-	height: ${(props) => (props.isShortLegend ? '100px' : '225px')};
+	height: ${(props) => (props.isShortLegend ? '125px' : '225px')};
 	overflow-y: scroll;
 `;
 

--- a/components/Charts/PieChart.tsx
+++ b/components/Charts/PieChart.tsx
@@ -2,11 +2,13 @@ import { FC } from 'react';
 import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
 
 import colors from '../../styles/colors';
-import { SynthTotalSupply } from '../../types/data';
 import CustomLegend from './CustomLegend';
 
 interface BasicPieChartProps {
-	data: SynthTotalSupply[];
+	data: {
+		name: string;
+		value: number;
+	}[];
 	isShortLegend: boolean;
 }
 
@@ -38,7 +40,7 @@ export const BRIGHT_COLORS = [
 ];
 
 const BasicPieChart: FC<BasicPieChartProps> = ({ data, isShortLegend }) => (
-	<ResponsiveContainer width="100%" height={isShortLegend ? '75%' : '100%'}>
+	<ResponsiveContainer width="100%" height={isShortLegend ? '80%' : '100%'}>
 		<PieChart height={380}>
 			<Pie
 				data={data}
@@ -50,7 +52,7 @@ const BasicPieChart: FC<BasicPieChartProps> = ({ data, isShortLegend }) => (
 				dataKey="value"
 				strokeWidth={1.5}
 			>
-				{data.map((entry: SynthTotalSupply, index: number) => (
+				{data.map((_, index: number) => (
 					<Cell
 						key={`cell-${index}`}
 						fill={MUTED_COLORS[index % MUTED_COLORS.length]}

--- a/components/Charts/SidewaysBarChart.tsx
+++ b/components/Charts/SidewaysBarChart.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import styled, { css, keyframes } from 'styled-components';
 
@@ -9,12 +9,18 @@ import { shortingLink } from 'constants/links';
 import { FlexDivCol, FlexDivRow, LinkText } from 'components/common';
 
 import InfoPopover from '../InfoPopover';
+import _ from 'lodash';
 interface SidewaysBarChartProps {
 	data: OpenInterest;
 }
 
 const SidewaysBarChart: FC<SidewaysBarChartProps> = ({ data }) => {
 	const { t } = useTranslation();
+
+	const totalValue = useMemo(() => {
+		return _.chain(data).values().map(_.values).flatten().map('value').max().value();
+	}, [data]);
+
 	return (
 		<ChartContainer>
 			<VerticalBar />
@@ -38,8 +44,6 @@ const SidewaysBarChart: FC<SidewaysBarChartProps> = ({ data }) => {
 						const shortSupply =
 							(data[key] && data[key][inverseName] && data[key][inverseName].shortSupply) || 0;
 
-						const totalValue = synthValue + inverseValue;
-
 						return (
 							<SynthContainer key={`synth-${key}`}>
 								<SynthLabels>
@@ -48,9 +52,9 @@ const SidewaysBarChart: FC<SidewaysBarChartProps> = ({ data }) => {
 											<FlexDivRow>
 												<SynthLabel>
 													{inverseName === 'iBTC' || inverseName === 'iETH'
-														? `${inverseName} + ${t('synth-bar-chart.shorts', {
+														? `${inverseName}, ${t('synth-bar-chart.shorts', {
 																asset: key,
-														  })}`
+														  })}, other collateral`
 														: inverseName}
 												</SynthLabel>
 												{isShort ? (

--- a/components/Charts/SidewaysBarChart.tsx
+++ b/components/Charts/SidewaysBarChart.tsx
@@ -5,8 +5,7 @@ import styled, { css, keyframes } from 'styled-components';
 import { formatCurrency, formatNumber } from 'utils/formatter';
 import { OpenInterest } from 'types/data';
 import colors from 'styles/colors';
-import { shortingLink } from 'constants/links';
-import { FlexDivCol, FlexDivRow, LinkText } from 'components/common';
+import { FlexDivCol, FlexDivRow } from 'components/common';
 
 import InfoPopover from '../InfoPopover';
 import _ from 'lodash';
@@ -64,10 +63,7 @@ const SidewaysBarChart: FC<SidewaysBarChartProps> = ({ data }) => {
 															<Trans
 																i18nKey="synth-bar-chart.info-data"
 																values={{
-																	link: t('synth-bar-chart.shortLinkText'),
-																}}
-																components={{
-																	linkText: <LinkText href={shortingLink} />,
+																	asset: inverseName.slice(1),
 																}}
 															/>
 														}

--- a/constants/links.ts
+++ b/constants/links.ts
@@ -21,5 +21,3 @@ export const synthetixOptionsSubgraph =
 export const etherscanArchernarBlock = 'https://etherscan.io/block/9518914';
 
 export const frontRunningWiki = 'https://en.wikipedia.org/wiki/Front_running';
-
-export const shortingLink = 'https://synthetix.surge.sh/';

--- a/sections/Options/index.tsx
+++ b/sections/Options/index.tsx
@@ -52,25 +52,28 @@ const Options: FC = () => {
 
 		[numMarkets, totalPoolSizes] = marketsData;
 
-		pieChartData = sortedMarkets.data!.reduce((acc: SynthTotalSupply[], curr: OptionsMarket) => {
-			if (Number(curr.poolSize) / totalPoolSizes! < MIN_PERCENT_FOR_PIE_CHART) {
-				const othersIndex = findIndex(acc, (o) => o.name === 'others');
-				if (othersIndex === -1) {
-					acc.push({ name: 'others', value: curr?.value ?? 0 });
+		pieChartData = sortedMarkets.data!.reduce(
+			(acc: { name: string; value: number }[], curr: OptionsMarket) => {
+				if (Number(curr.poolSize) / totalPoolSizes! < MIN_PERCENT_FOR_PIE_CHART) {
+					const othersIndex = findIndex(acc, (o) => o.name === 'others');
+					if (othersIndex === -1) {
+						acc.push({ name: 'others', value: curr?.value ?? 0 });
+					} else {
+						acc[othersIndex].value = acc[othersIndex].value + Number(curr.poolSize);
+					}
 				} else {
-					acc[othersIndex].value = acc[othersIndex].value + Number(curr.poolSize);
+					acc.push({
+						name: `${curr.currencyKey} > ${formatCurrency(curr.strikePrice)} @${format(
+							new Date(curr.maturityDate),
+							'MM/dd/yyyy'
+						)}`,
+						value: Number(curr.poolSize),
+					});
 				}
-			} else {
-				acc.push({
-					name: `${curr.currencyKey} > ${formatCurrency(curr.strikePrice)} @${format(
-						new Date(curr.maturityDate),
-						'MM/dd/yyyy'
-					)}`,
-					value: Number(curr.poolSize),
-				});
-			}
-			return acc;
-		}, []);
+				return acc;
+			},
+			[]
+		);
 	}
 
 	const yesterday = new Date();

--- a/sections/Staking/Liquidations.tsx
+++ b/sections/Staking/Liquidations.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { CellProps } from 'react-table';
 
-import { NO_VALUE } from 'constants/placeholder';
 import { CryptoCurrency } from 'constants/currency';
 import { LiquidationsData } from 'queries/staking';
 

--- a/sections/Staking/index.tsx
+++ b/sections/Staking/index.tsx
@@ -11,7 +11,6 @@ import { NewParagraph, LinkText } from 'components/common';
 import {
 	useFeePeriodQuery,
 	useLiquidationsQuery,
-	LiquidationsData,
 	useAggregateActiveStakersQuery,
 } from 'queries/staking';
 import { COLORS } from 'constants/styles';

--- a/sections/Synths/index.tsx
+++ b/sections/Synths/index.tsx
@@ -181,7 +181,8 @@ const SynthsSection: FC<{}> = () => {
 			const synthObject: SynthTotalSupply = {
 				name,
 				totalSupply,
-				value: combinedWithExtrasValue,
+				value,
+				valueWithAdjust: combinedWithExtrasValue,
 			};
 
 			unsortedOpenInterest.push(synthObject);
@@ -202,7 +203,7 @@ const SynthsSection: FC<{}> = () => {
 
 				const subObject = {
 					[curr.name]: {
-						value: curr.value,
+						value: curr.valueWithAdjust,
 						totalSupply: curr.totalSupply ?? 0,
 						isShort,
 						shortSupply: isEthShort ? ethShorts : isBtcShort ? btcShorts : null,

--- a/translations/en.json
+++ b/translations/en.json
@@ -177,7 +177,7 @@
 		"shorts": "{{asset}} Shorts",
 		"wrapper": "{{asset}} Wrapper",
 		"shortLinkText": "Synthetix Surge",
-		"info-data": "It is possible to short {{asset}} without buying an inverse synth. You borrow a loan in s{{asset}} terms, but receive the equivalent value in sUSD instead, thereby going short. The UI for this mechanism is available at the <linkText>{{link}}</linkText> site.\n\nAdditionally, debt pool corrections for wrappr or collateral loans bay be included here."
+		"info-data": "It is possible to short {{asset}} without buying an inverse synth. A loan is borrowed in s{{asset}} terms, but receive the equivalent value in sUSD instead, thereby going short.\n\nAdditionally, debt pool corrections for wrappr or collateral loans bay be included here."
 	},
 	"synth-pie-chart": {
 		"title": "SYNTH DOMINANCE",

--- a/translations/en.json
+++ b/translations/en.json
@@ -177,11 +177,14 @@
 		"shorts": "{{asset}} Shorts",
 		"wrapper": "{{asset}} Wrapper",
 		"shortLinkText": "Synthetix Surge",
-		"info-data": "It is possible to short {{asset}} without buying an inverse synth. You borrow a loan in s{{asset}} terms, but receive the equivalent value in sUSD instead, thereby going short. The UI for this mechanism is available at the <linkText>{{link}}</linkText> site"
+		"info-data": "It is possible to short {{asset}} without buying an inverse synth. You borrow a loan in s{{asset}} terms, but receive the equivalent value in sUSD instead, thereby going short. The UI for this mechanism is available at the <linkText>{{link}}</linkText> site.\n\nAdditionally, debt pool corrections for wrappr or collateral loans bay be included here."
 	},
 	"synth-pie-chart": {
 		"title": "SYNTH DOMINANCE",
 		"subtext": "Distribution of Synth Debt within the Synthetix protocol"
+	},
+	"debt-pie-chart": {
+		"title": "DEBT RESPONSIBILITY"
 	},
 	"total-trading-volume": {
 		"title": "TOTAL TRADING VOLUME",

--- a/types/data.ts
+++ b/types/data.ts
@@ -13,8 +13,7 @@ export type SynthTotalSupply = {
 	name: string;
 	totalSupply?: number;
 	value: number;
-	wrapperAmount?: number;
-	wrapperAmountUSD?: number;
+	valueWithAdjust: number;
 	maxLimit?: number;
 };
 


### PR DESCRIPTION
* add pie chart to show debt pool responsibility for wrappr, snx stakers, etc.
* add corrections for wrappr, collateral loans to synths breakdown
* change synths breakdown to show relative sizes correctly

/hours 2