### PR TITLE
remove now-unavailable short rewards from yield farming section

### DIFF
--- a/sections/YieldFarming/index.tsx
+++ b/sections/YieldFarming/index.tsx
@@ -46,20 +46,6 @@ const YieldFarming: FC = () => {
 			curvepoolRewards.address,
 			'curve'
 		),
-		ShortsETH: useRewardsContractInfo(
-			snxjs,
-			provider,
-			'sETH',
-			snxjs.contracts.ShortingRewardssETH.address,
-			'shorting'
-		),
-		ShortsBTC: useRewardsContractInfo(
-			snxjs,
-			provider,
-			'sBTC',
-			snxjs.contracts.ShortingRewardssBTC.address,
-			'shorting'
-		),
 	};
 
 	const aaveDepositInfo = usePageResults<any[]>({


### PR DESCRIPTION
sETH and sBTC shorts rewards were removed this week. THis removes the boxes.

There is a bug with the APY display where it uses the emission rate of the contract, but ignores the lack of balance, and therefore shows incorrect APY, but that has not yet been fixed in this PR.