### PR TITLE
temporarily add L2 stats to bottom of page

### DIFF
--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -1,9 +1,12 @@
+import { SynthetixJS } from '@synthetixio/contracts-interface';
+
 export default {
 	CMC: (symbol: string) => ['cmc', symbol],
 	PageResults: (query: any) => ['pageResults', query],
-	SnxjsContract: (contract: string, method: string, args: any[]) => [
+	SnxjsContract: (snxjs: SynthetixJS, contract: string, method: string, args: any[]) => [
 		'snxjs',
 		'contract',
+		snxjs.network,
 		contract,
 		method,
 		args,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@material-ui/core": "4.11.0",
 				"@material-ui/lab": "4.0.0-alpha.56",
-				"@synthetixio/contracts-interface": "2.45.2",
+				"@synthetixio/contracts-interface": "2.47.0-ovm.5",
 				"axios": "0.21.1",
 				"bignumber.js": "9.0.0",
 				"bnc-notify": "1.3.1",
@@ -2348,32 +2348,6 @@
 				"js-sha3": "^0.8.0"
 			}
 		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/abi": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
-			"integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/address": "^5.4.0",
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/constants": "^5.4.0",
-				"@ethersproject/hash": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0"
-			}
-		},
 		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/abstract-provider": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
@@ -2420,65 +2394,6 @@
 				"@ethersproject/properties": "^5.4.0"
 			}
 		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/address": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
-			"integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/rlp": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/base64": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
-			"integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/basex": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
-			"integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0"
-			}
-		},
 		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/bignumber": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
@@ -2497,42 +2412,6 @@
 				"@ethersproject/bytes": "^5.4.0",
 				"@ethersproject/logger": "^5.4.0",
 				"bn.js": "^4.11.9"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/bytes": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
-			"integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/constants": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
-			"integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.4.0"
 			}
 		},
 		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/contracts": {
@@ -2562,170 +2441,10 @@
 				"@ethersproject/transactions": "^5.4.0"
 			}
 		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/hash": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
-			"integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/abstract-signer": "^5.4.0",
-				"@ethersproject/address": "^5.4.0",
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/hdnode": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
-			"integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/abstract-signer": "^5.4.0",
-				"@ethersproject/basex": "^5.4.0",
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/pbkdf2": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/sha2": "^5.4.0",
-				"@ethersproject/signing-key": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0",
-				"@ethersproject/transactions": "^5.4.0",
-				"@ethersproject/wordlists": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/json-wallets": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
-			"integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/abstract-signer": "^5.4.0",
-				"@ethersproject/address": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/hdnode": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/pbkdf2": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/random": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0",
-				"@ethersproject/transactions": "^5.4.0",
-				"aes-js": "3.0.0",
-				"scrypt-js": "3.0.1"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/keccak256": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
-			"integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"js-sha3": "0.5.7"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/keccak256/node_modules/js-sha3": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-			"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/logger": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
-			"integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			]
-		},
 		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/networks": {
 			"version": "5.4.2",
 			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
 			"integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/pbkdf2": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
-			"integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/sha2": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/properties": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
-			"integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2774,265 +2493,6 @@
 				"@ethersproject/web": "^5.4.0",
 				"bech32": "1.1.4",
 				"ws": "7.4.6"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/random": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
-			"integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/rlp": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
-			"integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/sha2": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
-			"integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"hash.js": "1.1.7"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/signing-key": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
-			"integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"bn.js": "^4.11.9",
-				"elliptic": "6.5.4",
-				"hash.js": "1.1.7"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/solidity": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
-			"integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/sha2": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/strings": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
-			"integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/constants": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/transactions": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
-			"integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/address": "^5.4.0",
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/constants": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/rlp": "^5.4.0",
-				"@ethersproject/signing-key": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/units": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
-			"integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/constants": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/wallet": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
-			"integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/abstract-provider": "^5.4.0",
-				"@ethersproject/abstract-signer": "^5.4.0",
-				"@ethersproject/address": "^5.4.0",
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/hash": "^5.4.0",
-				"@ethersproject/hdnode": "^5.4.0",
-				"@ethersproject/json-wallets": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/random": "^5.4.0",
-				"@ethersproject/signing-key": "^5.4.0",
-				"@ethersproject/transactions": "^5.4.0",
-				"@ethersproject/wordlists": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/web": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
-			"integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/base64": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/@ethersproject/wordlists": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
-			"integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/hash": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0"
-			}
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-			"dependencies": {
-				"bn.js": "^4.11.9",
-				"brorand": "^1.1.0",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.1",
-				"inherits": "^2.0.4",
-				"minimalistic-assert": "^1.0.1",
-				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"node_modules/@ensdomains/ensjs/node_modules/ethers": {
@@ -3086,26 +2546,6 @@
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
 			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-		},
-		"node_modules/@ensdomains/ensjs/node_modules/ws": {
-			"version": "7.4.6",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/@ensdomains/resolver": {
 			"version": "0.2.4",
@@ -3190,377 +2630,671 @@
 			}
 		},
 		"node_modules/@ethersproject/abi": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.10.tgz",
-			"integrity": "sha512-cfC3lGgotfxX3SMri4+CisOPwignoj/QGHW9J29spC4R4Qqcnk/SYuVkPFBMdLbvBp3f/pGiVqPNwont0TSXhg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
+			"integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/hash": "^5.0.10",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8"
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/hash": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/abstract-provider": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
-			"integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
+			"integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/networks": "^5.0.7",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/transactions": "^5.0.9",
-				"@ethersproject/web": "^5.0.12"
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/networks": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0",
+				"@ethersproject/web": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/abstract-signer": {
-			"version": "5.0.11",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.11.tgz",
-			"integrity": "sha512-RKOgPSEYafknA62SrD3OCK42AllHE4YBfKYXyQeM+sBP7Nq3X5FpzeoY4uzC43P4wIhmNoTHCKQuwnX7fBqb6Q==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
+			"integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/abstract-provider": "^5.0.8",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7"
+				"@ethersproject/abstract-provider": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/address": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
-			"integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+			"integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/rlp": "^5.0.7"
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/rlp": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/base64": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
-			"integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+			"integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9"
+				"@ethersproject/bytes": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/basex": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.7.tgz",
-			"integrity": "sha512-OsXnRsujGmYD9LYyJlX+cVe5KfwgLUbUJrJMWdzRWogrygXd5HvGd7ygX1AYjlu1z8W/+t2FoQnczDR/H2iBjA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
+			"integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/properties": "^5.0.7"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/bignumber": {
-			"version": "5.0.13",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
-			"integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
+			"integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"bn.js": "^4.4.0"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"bn.js": "^4.11.9"
 			}
 		},
 		"node_modules/@ethersproject/bytes": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
-			"integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+			"integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/constants": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
-			"integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+			"integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.0.13"
+				"@ethersproject/bignumber": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/contracts": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.9.tgz",
-			"integrity": "sha512-CCTxVeDh6sjdSEbjzONhtwPjECvaHE62oGkY8M7kP0CHmgLD2SEGel0HZib8e5oQKRKGly9AKcUFW4g3rQ0AQw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.0.tgz",
+			"integrity": "sha512-hkO3L3IhS1Z3ZtHtaAG/T87nQ7KiPV+/qnvutag35I0IkiQ8G3ZpCQ9NNOpSCzn4pWSW4CfzmtE02FcqnLI+hw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/abi": "^5.0.10",
-				"@ethersproject/abstract-provider": "^5.0.8",
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7"
+				"@ethersproject/abi": "^5.4.0",
+				"@ethersproject/abstract-provider": "^5.4.0",
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/hash": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
-			"integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+			"integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8"
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/hdnode": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.8.tgz",
-			"integrity": "sha512-Mscpjd7BBjxYSWghaNMwV0xrBBkOoCq6YEPRm9MgE24CiBlzzbfEB5DGq6hiZqhQaxPkdCUtKKqZi3nt9hx43g==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
+			"integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/basex": "^5.0.7",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/pbkdf2": "^5.0.7",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/sha2": "^5.0.7",
-				"@ethersproject/signing-key": "^5.0.8",
-				"@ethersproject/strings": "^5.0.8",
-				"@ethersproject/transactions": "^5.0.9",
-				"@ethersproject/wordlists": "^5.0.8"
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/basex": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/pbkdf2": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/sha2": "^5.4.0",
+				"@ethersproject/signing-key": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0",
+				"@ethersproject/wordlists": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/json-wallets": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.10.tgz",
-			"integrity": "sha512-Ux36u+d7Dm0M5AQ+mWuHdvfGPMN8K1aaLQgwzrsD4ELTWlwRuHuQbmn7/GqeOpbfaV6POLwdYcBk2TXjlGp/IQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
+			"integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/hdnode": "^5.0.8",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/pbkdf2": "^5.0.7",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/random": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8",
-				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/hdnode": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/pbkdf2": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/random": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0",
 				"aes-js": "3.0.0",
 				"scrypt-js": "3.0.1"
 			}
 		},
 		"node_modules/@ethersproject/keccak256": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
-			"integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+			"integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/bytes": "^5.4.0",
 				"js-sha3": "0.5.7"
 			}
 		},
 		"node_modules/@ethersproject/logger": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-			"integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+			"integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			]
 		},
 		"node_modules/@ethersproject/networks": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
-			"integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.1.tgz",
+			"integrity": "sha512-8SvowCKz9Uf4xC5DTKI8+il8lWqOr78kmiqAVLYT9lzB8aSmJHQMD1GSuJI0CW4hMAnzocpGpZLgiMdzsNSPig==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/pbkdf2": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.7.tgz",
-			"integrity": "sha512-0SNLNixPMqnosH6pyc4yPiUu/C9/Jbu+f6I8GJW9U2qNpMBddmRJviwseoha5Zw1V+Aw0Z/yvYyzIIE8yPXqLA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
+			"integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/sha2": "^5.0.7"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/sha2": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/properties": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
-			"integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
+			"integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/providers": {
-			"version": "5.0.19",
-			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.19.tgz",
-			"integrity": "sha512-G+flo1jK1y/rvQy6b71+Nu7qOlkOKz+XqpgqFMZslkCzGuzQRmk9Qp7Ln4soK8RSyP1e5TCujaRf1H+EZahoaw==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.1.tgz",
+			"integrity": "sha512-p06eiFKz8nu/5Ju0kIX024gzEQIgE5pvvGrBCngpyVjpuLtUIWT3097Agw4mTn9/dEA0FMcfByzFqacBMSgCVg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/abstract-provider": "^5.0.8",
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/basex": "^5.0.7",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/hash": "^5.0.10",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/networks": "^5.0.7",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/random": "^5.0.7",
-				"@ethersproject/rlp": "^5.0.7",
-				"@ethersproject/sha2": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8",
-				"@ethersproject/transactions": "^5.0.9",
-				"@ethersproject/web": "^5.0.12",
+				"@ethersproject/abstract-provider": "^5.4.0",
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/basex": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/hash": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/networks": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/random": "^5.4.0",
+				"@ethersproject/rlp": "^5.4.0",
+				"@ethersproject/sha2": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0",
+				"@ethersproject/web": "^5.4.0",
 				"bech32": "1.1.4",
-				"ws": "7.2.3"
+				"ws": "7.4.6"
 			}
 		},
 		"node_modules/@ethersproject/random": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.7.tgz",
-			"integrity": "sha512-PxSRWwN3s+FH9AWMZU6AcWJsNQ9KzqKV6NgdeKPtxahdDjCuXxTAuzTZNXNRK+qj+Il351UnweAGd+VuZcOAlQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
+			"integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/rlp": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
-			"integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+			"integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/sha2": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.7.tgz",
-			"integrity": "sha512-MbUqz68hhp5RsaZdqi1eg1rrtiqt5wmhRYqdA7MX8swBkzW2KiLgK+Oh25UcWhUhdi1ImU9qrV6if5j0cC7Bxg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
+			"integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"hash.js": "1.1.3"
-			}
-		},
-		"node_modules/@ethersproject/sha2/node_modules/hash.js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.0"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"hash.js": "1.1.7"
 			}
 		},
 		"node_modules/@ethersproject/signing-key": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
-			"integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+			"integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"elliptic": "6.5.3"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"bn.js": "^4.11.9",
+				"elliptic": "6.5.4",
+				"hash.js": "1.1.7"
 			}
 		},
 		"node_modules/@ethersproject/solidity": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.8.tgz",
-			"integrity": "sha512-OJkyBq9KaoGsi8E8mYn6LX+vKyCURvxSp0yuGBcOqEFM3vkn9PsCiXsHdOXdNBvlHG5evJXwAYC2UR0TzgJeKA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
+			"integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/sha2": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8"
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/sha2": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/strings": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
-			"integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+			"integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/transactions": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
-			"integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+			"integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/rlp": "^5.0.7",
-				"@ethersproject/signing-key": "^5.0.8"
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/rlp": "^5.4.0",
+				"@ethersproject/signing-key": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/units": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.9.tgz",
-			"integrity": "sha512-4jIkcMVrJ3lCgXMO4M/2ww0/T/IN08vJTZld7FIAwa6aoBDTAy71+sby3sShl1SG3HEeKYbI3fBWauCUgPRUpQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
+			"integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/wallet": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.10.tgz",
-			"integrity": "sha512-5siYr38NhqZKH6DUr6u4PdhgOKur8Q6sw+JID2TitEUmW0tOl8f6rpxAe77tw6SJT60D2UcvgsyLtl32+Nl+ig==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
+			"integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/abstract-provider": "^5.0.8",
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/hash": "^5.0.10",
-				"@ethersproject/hdnode": "^5.0.8",
-				"@ethersproject/json-wallets": "^5.0.10",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/random": "^5.0.7",
-				"@ethersproject/signing-key": "^5.0.8",
-				"@ethersproject/transactions": "^5.0.9",
-				"@ethersproject/wordlists": "^5.0.8"
+				"@ethersproject/abstract-provider": "^5.4.0",
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/hash": "^5.4.0",
+				"@ethersproject/hdnode": "^5.4.0",
+				"@ethersproject/json-wallets": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/random": "^5.4.0",
+				"@ethersproject/signing-key": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0",
+				"@ethersproject/wordlists": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/web": {
-			"version": "5.0.12",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
-			"integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+			"integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/base64": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8"
+				"@ethersproject/base64": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0"
 			}
 		},
 		"node_modules/@ethersproject/wordlists": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.8.tgz",
-			"integrity": "sha512-px2mloc1wAcdTbzv0ZotTx+Uh/dfnDO22D9Rx8xr7+/PUwAhZQjoJ9t7Hn72nsaN83rWBXsLvFcIRZju4GIaEQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
+			"integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/hash": "^5.0.10",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/hash": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0"
 			}
 		},
 		"node_modules/@gnosis.pm/safe-apps-provider": {
@@ -4414,51 +4148,61 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/@synthetixio/contracts-interface": {
-			"version": "2.45.2",
-			"resolved": "https://registry.npmjs.org/@synthetixio/contracts-interface/-/contracts-interface-2.45.2.tgz",
-			"integrity": "sha512-c27pLIIwNlZiNEAG1gREX8BewDWcr+L37a7+qL2ME7HwsliM5PM3/L3tNOpQ53vW/CacRvBRWLDcbjqp57gk7A==",
+			"version": "2.47.0-ovm.5",
+			"resolved": "https://registry.npmjs.org/@synthetixio/contracts-interface/-/contracts-interface-2.47.0-ovm.5.tgz",
+			"integrity": "sha512-yzvaLyJyUxZAZH7cSLLI8HKA1j9svxsiJ+DjGLXDzOEadhfUPGPGGaMwQ+l1JSkiyUNw7qNHplg8myjcSHeL6w==",
 			"dependencies": {
-				"ethers": "5.0.26",
+				"ethers": "5.4.1",
 				"lodash": "4.17.19",
-				"synthetix": "2.45.2",
+				"synthetix": "2.47.0-ovm",
 				"web3-utils": "1.2.11"
 			}
 		},
 		"node_modules/@synthetixio/contracts-interface/node_modules/ethers": {
-			"version": "5.0.26",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.26.tgz",
-			"integrity": "sha512-MqA8Fvutn3qEW0yBJOHeV6KZmRpF2rqlL2B5058AGkUFsuu6j5Ns/FRlMsbGeQwBz801IB23jQp7vjRfFsKSkg==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.1.tgz",
+			"integrity": "sha512-SrcddMdCgP1hukDvCPd87Aipbf4NWjQvdfAbZ65XSZGbfyuYPtIrUJPDH5B1SBRsdlfiEgX3eoz28DdBDzMNFg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
 			"dependencies": {
-				"@ethersproject/abi": "5.0.10",
-				"@ethersproject/abstract-provider": "5.0.8",
-				"@ethersproject/abstract-signer": "5.0.11",
-				"@ethersproject/address": "5.0.9",
-				"@ethersproject/base64": "5.0.7",
-				"@ethersproject/basex": "5.0.7",
-				"@ethersproject/bignumber": "5.0.13",
-				"@ethersproject/bytes": "5.0.9",
-				"@ethersproject/constants": "5.0.8",
-				"@ethersproject/contracts": "5.0.9",
-				"@ethersproject/hash": "5.0.10",
-				"@ethersproject/hdnode": "5.0.8",
-				"@ethersproject/json-wallets": "5.0.10",
-				"@ethersproject/keccak256": "5.0.7",
-				"@ethersproject/logger": "5.0.8",
-				"@ethersproject/networks": "5.0.7",
-				"@ethersproject/pbkdf2": "5.0.7",
-				"@ethersproject/properties": "5.0.7",
-				"@ethersproject/providers": "5.0.19",
-				"@ethersproject/random": "5.0.7",
-				"@ethersproject/rlp": "5.0.7",
-				"@ethersproject/sha2": "5.0.7",
-				"@ethersproject/signing-key": "5.0.8",
-				"@ethersproject/solidity": "5.0.8",
-				"@ethersproject/strings": "5.0.8",
-				"@ethersproject/transactions": "5.0.9",
-				"@ethersproject/units": "5.0.9",
-				"@ethersproject/wallet": "5.0.10",
-				"@ethersproject/web": "5.0.12",
-				"@ethersproject/wordlists": "5.0.8"
+				"@ethersproject/abi": "5.4.0",
+				"@ethersproject/abstract-provider": "5.4.0",
+				"@ethersproject/abstract-signer": "5.4.0",
+				"@ethersproject/address": "5.4.0",
+				"@ethersproject/base64": "5.4.0",
+				"@ethersproject/basex": "5.4.0",
+				"@ethersproject/bignumber": "5.4.0",
+				"@ethersproject/bytes": "5.4.0",
+				"@ethersproject/constants": "5.4.0",
+				"@ethersproject/contracts": "5.4.0",
+				"@ethersproject/hash": "5.4.0",
+				"@ethersproject/hdnode": "5.4.0",
+				"@ethersproject/json-wallets": "5.4.0",
+				"@ethersproject/keccak256": "5.4.0",
+				"@ethersproject/logger": "5.4.0",
+				"@ethersproject/networks": "5.4.1",
+				"@ethersproject/pbkdf2": "5.4.0",
+				"@ethersproject/properties": "5.4.0",
+				"@ethersproject/providers": "5.4.1",
+				"@ethersproject/random": "5.4.0",
+				"@ethersproject/rlp": "5.4.0",
+				"@ethersproject/sha2": "5.4.0",
+				"@ethersproject/signing-key": "5.4.0",
+				"@ethersproject/solidity": "5.4.0",
+				"@ethersproject/strings": "5.4.0",
+				"@ethersproject/transactions": "5.4.0",
+				"@ethersproject/units": "5.4.0",
+				"@ethersproject/wallet": "5.4.0",
+				"@ethersproject/web": "5.4.0",
+				"@ethersproject/wordlists": "5.4.0"
 			}
 		},
 		"node_modules/@synthetixio/contracts-interface/node_modules/lodash": {
@@ -4490,20 +4234,6 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/@toruslabs/eccrypto/node_modules/elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-			"dependencies": {
-				"bn.js": "^4.11.9",
-				"brorand": "^1.1.0",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.1",
-				"inherits": "^2.0.4",
-				"minimalistic-assert": "^1.0.1",
-				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"node_modules/@toruslabs/eccrypto/node_modules/secp256k1": {
@@ -4652,25 +4382,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
 			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-		},
-		"node_modules/@toruslabs/torus.js/node_modules/elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-			"dependencies": {
-				"bn.js": "^4.11.9",
-				"brorand": "^1.1.0",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.1",
-				"inherits": "^2.0.4",
-				"minimalistic-assert": "^1.0.1",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
-		"node_modules/@toruslabs/torus.js/node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 		},
 		"node_modules/@toruslabs/torus.js/node_modules/web3-utils": {
 			"version": "1.5.1",
@@ -7465,8 +7176,7 @@
 		"node_modules/chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-			"dev": true
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 		},
 		"node_modules/checkpoint-store": {
 			"version": "1.1.0",
@@ -8312,14 +8022,18 @@
 			"integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
 		},
 		"node_modules/css-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-			"integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+			"integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
 			"dependencies": {
 				"boolbase": "^1.0.0",
-				"css-what": "^3.2.1",
-				"domutils": "^1.7.0",
-				"nth-check": "^1.0.2"
+				"css-what": "^5.0.0",
+				"domhandler": "^4.2.0",
+				"domutils": "^2.6.0",
+				"nth-check": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/css-to-react-native": {
@@ -8342,11 +8056,14 @@
 			}
 		},
 		"node_modules/css-what": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-			"integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+			"integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
 			"engines": {
 				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/css.escape": {
@@ -8835,12 +8552,16 @@
 			"integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
 		},
 		"node_modules/dom-serializer": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+			"integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
 			"dependencies": {
 				"domelementtype": "^2.0.1",
+				"domhandler": "^4.2.0",
 				"entities": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
 			}
 		},
 		"node_modules/dom-walk": {
@@ -8863,31 +8584,31 @@
 			"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
 		},
 		"node_modules/domhandler": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+			"integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
 			"dependencies": {
-				"domelementtype": "1"
+				"domelementtype": "^2.2.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
 			}
-		},
-		"node_modules/domhandler/node_modules/domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
 		},
 		"node_modules/domutils": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+			"integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
 			"dependencies": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
+				"dom-serializer": "^1.0.1",
+				"domelementtype": "^2.2.0",
+				"domhandler": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
-		},
-		"node_modules/domutils/node_modules/domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
 		},
 		"node_modules/drbg.js": {
 			"version": "1.0.1",
@@ -8987,17 +8708,17 @@
 			}
 		},
 		"node_modules/elliptic": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
 			"dependencies": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
 				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"node_modules/emoji-regex": {
@@ -11123,7 +10844,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
 			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"dev": true,
 			"dependencies": {
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
@@ -12830,32 +12550,6 @@
 				"superagent": "^3.8.3"
 			}
 		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/abi": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
-			"integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/address": "^5.4.0",
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/constants": "^5.4.0",
-				"@ethersproject/hash": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0"
-			}
-		},
 		"node_modules/gridplus-sdk/node_modules/@ethersproject/abstract-provider": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
@@ -12902,65 +12596,6 @@
 				"@ethersproject/properties": "^5.4.0"
 			}
 		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/address": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
-			"integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/rlp": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/base64": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
-			"integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/basex": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
-			"integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0"
-			}
-		},
 		"node_modules/gridplus-sdk/node_modules/@ethersproject/bignumber": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
@@ -12979,42 +12614,6 @@
 				"@ethersproject/bytes": "^5.4.0",
 				"@ethersproject/logger": "^5.4.0",
 				"bn.js": "^4.11.9"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/bytes": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
-			"integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/constants": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
-			"integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.4.0"
 			}
 		},
 		"node_modules/gridplus-sdk/node_modules/@ethersproject/contracts": {
@@ -13044,175 +12643,10 @@
 				"@ethersproject/transactions": "^5.4.0"
 			}
 		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/hash": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
-			"integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/abstract-signer": "^5.4.0",
-				"@ethersproject/address": "^5.4.0",
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/hdnode": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
-			"integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/abstract-signer": "^5.4.0",
-				"@ethersproject/basex": "^5.4.0",
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/pbkdf2": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/sha2": "^5.4.0",
-				"@ethersproject/signing-key": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0",
-				"@ethersproject/transactions": "^5.4.0",
-				"@ethersproject/wordlists": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/json-wallets": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
-			"integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/abstract-signer": "^5.4.0",
-				"@ethersproject/address": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/hdnode": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/pbkdf2": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/random": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0",
-				"@ethersproject/transactions": "^5.4.0",
-				"aes-js": "3.0.0",
-				"scrypt-js": "3.0.1"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/keccak256": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
-			"integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"js-sha3": "0.5.7"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/keccak256/node_modules/js-sha3": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-			"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/logger": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
-			"integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			]
-		},
 		"node_modules/gridplus-sdk/node_modules/@ethersproject/networks": {
 			"version": "5.4.2",
 			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
 			"integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/pbkdf2": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
-			"integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/sha2": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/properties": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
-			"integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
 			"funding": [
 				{
 					"type": "individual",
@@ -13268,251 +12702,6 @@
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
 			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
 		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/random": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
-			"integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/rlp": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
-			"integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/sha2": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
-			"integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"hash.js": "1.1.7"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/signing-key": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
-			"integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"bn.js": "^4.11.9",
-				"elliptic": "6.5.4",
-				"hash.js": "1.1.7"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/solidity": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
-			"integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/sha2": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/strings": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
-			"integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/constants": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/transactions": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
-			"integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/address": "^5.4.0",
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/constants": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/rlp": "^5.4.0",
-				"@ethersproject/signing-key": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/units": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
-			"integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/constants": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/wallet": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
-			"integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/abstract-provider": "^5.4.0",
-				"@ethersproject/abstract-signer": "^5.4.0",
-				"@ethersproject/address": "^5.4.0",
-				"@ethersproject/bignumber": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/hash": "^5.4.0",
-				"@ethersproject/hdnode": "^5.4.0",
-				"@ethersproject/json-wallets": "^5.4.0",
-				"@ethersproject/keccak256": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/random": "^5.4.0",
-				"@ethersproject/signing-key": "^5.4.0",
-				"@ethersproject/transactions": "^5.4.0",
-				"@ethersproject/wordlists": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/web": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
-			"integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/base64": "^5.4.0",
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/@ethersproject/wordlists": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
-			"integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/bytes": "^5.4.0",
-				"@ethersproject/hash": "^5.4.0",
-				"@ethersproject/logger": "^5.4.0",
-				"@ethersproject/properties": "^5.4.0",
-				"@ethersproject/strings": "^5.4.0"
-			}
-		},
 		"node_modules/gridplus-sdk/node_modules/aes-js": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
@@ -13529,20 +12718,6 @@
 			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/gridplus-sdk/node_modules/elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-			"dependencies": {
-				"bn.js": "^4.11.9",
-				"brorand": "^1.1.0",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.1",
-				"inherits": "^2.0.4",
-				"minimalistic-assert": "^1.0.1",
-				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"node_modules/gridplus-sdk/node_modules/ethers": {
@@ -13596,26 +12771,6 @@
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
 			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-		},
-		"node_modules/gridplus-sdk/node_modules/ws": {
-			"version": "7.4.6",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/har-schema": {
 			"version": "2.0.0",
@@ -13853,27 +13008,22 @@
 			}
 		},
 		"node_modules/htmlparser2": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+			"integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
 			"dependencies": {
-				"domelementtype": "^1.3.1",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.1.1"
+				"domelementtype": "^2.0.1",
+				"domhandler": "^4.0.0",
+				"domutils": "^2.5.2",
+				"entities": "^2.0.0"
 			}
-		},
-		"node_modules/htmlparser2/node_modules/domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-		},
-		"node_modules/htmlparser2/node_modules/entities": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 		},
 		"node_modules/http-https": {
 			"version": "1.0.0",
@@ -14026,7 +13176,6 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			},
@@ -14837,6 +13986,14 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/js-levenshtein": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+			"integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/js-sha3": {
@@ -17191,11 +16348,14 @@
 			}
 		},
 		"node_modules/nth-check": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+			"integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
 			"dependencies": {
-				"boolbase": "~1.0.0"
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
 		"node_modules/number-is-nan": {
@@ -17555,7 +16715,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -18970,15 +18129,15 @@
 			"optional": true
 		},
 		"node_modules/renderkid": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.5.tgz",
-			"integrity": "sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
+			"integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
 			"dependencies": {
-				"css-select": "^2.0.2",
-				"dom-converter": "^0.2",
-				"htmlparser2": "^3.10.1",
-				"lodash": "^4.17.20",
-				"strip-ansi": "^3.0.0"
+				"css-select": "^4.1.3",
+				"dom-converter": "^0.2.0",
+				"htmlparser2": "^6.1.0",
+				"lodash": "^4.17.21",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"node_modules/renderkid/node_modules/ansi-regex": {
@@ -18988,6 +18147,11 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/renderkid/node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/renderkid/node_modules/strip-ansi": {
 			"version": "3.0.1",
@@ -19303,7 +18467,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
 			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -20850,12 +20013,15 @@
 			}
 		},
 		"node_modules/synthetix": {
-			"version": "2.45.2",
-			"resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.45.2.tgz",
-			"integrity": "sha512-m3QZnXXQ8ls09qRoyrlCwHlaS5m4aFtDgZWBRONc+d5img6LQbH/Y9biZk0fZ0Ccr6nhc5yj4BcVuXEajufCZw==",
+			"version": "2.47.0-ovm",
+			"resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.47.0-ovm.tgz",
+			"integrity": "sha512-YCcNhZdCgoT4dcXHS6YWavNDLDIthAEr8/fs0+BqfT7/vf+Ny1X7Zq0+qg6gRZpKBKDFiD9iyT1YFzF7z1gc2Q==",
 			"dependencies": {
 				"abi-decoder": "2.3.0",
 				"commander": "5.1.0",
+				"inquirer": "^6.5.2",
+				"inquirer-list-search-prompt": "^1.0.2",
+				"js-levenshtein": "^1.1.6",
 				"pretty-error": "^2.1.1",
 				"solidity-parser-antlr": "^0.4.11",
 				"web3-utils": "1.2.2"
@@ -20909,10 +20075,42 @@
 				"async-limiter": "^1.0.0"
 			}
 		},
+		"node_modules/synthetix/node_modules/ansi-escapes": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/synthetix/node_modules/ansi-regex": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/synthetix/node_modules/bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+		},
+		"node_modules/synthetix/node_modules/cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dependencies": {
+				"restore-cursor": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/synthetix/node_modules/cli-width": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
 		},
 		"node_modules/synthetix/node_modules/eth-lib": {
 			"version": "0.2.7",
@@ -20922,6 +20120,104 @@
 				"bn.js": "^4.11.6",
 				"elliptic": "^6.4.0",
 				"xhr-request-promise": "^0.1.2"
+			}
+		},
+		"node_modules/synthetix/node_modules/figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dependencies": {
+				"escape-string-regexp": "^1.0.5"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/synthetix/node_modules/inquirer": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+			"dependencies": {
+				"ansi-escapes": "^3.2.0",
+				"chalk": "^2.4.2",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.12",
+				"mute-stream": "0.0.7",
+				"run-async": "^2.2.0",
+				"rxjs": "^6.4.0",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^5.1.0",
+				"through": "^2.3.6"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/synthetix/node_modules/inquirer-list-search-prompt": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/inquirer-list-search-prompt/-/inquirer-list-search-prompt-1.0.2.tgz",
+			"integrity": "sha512-p2pxuhxCurxZbWkYydLaI+9f2qkSDQUB2MeIJ07jxNBqH/bkHcz7Kk78+Im/XnL1MdyHbh0KKMzjAHmeSLn7oA==",
+			"dependencies": {
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"figures": "^2.0.0",
+				"run-async": "^2.3.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			},
+			"peerDependencies": {
+				"inquirer": "^5.0.0 || ^6.0.0"
+			}
+		},
+		"node_modules/synthetix/node_modules/mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/synthetix/node_modules/mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+		},
+		"node_modules/synthetix/node_modules/onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dependencies": {
+				"mimic-fn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/synthetix/node_modules/restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dependencies": {
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/synthetix/node_modules/strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dependencies": {
+				"ansi-regex": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/synthetix/node_modules/web3-utils": {
@@ -21305,8 +20601,7 @@
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"node_modules/through2": {
 			"version": "2.0.5",
@@ -21388,7 +20683,6 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"dependencies": {
 				"os-tmpdir": "~1.0.2"
 			},
@@ -23298,11 +22592,23 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+			"version": "7.4.6",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
 			"engines": {
 				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/xhr": {
@@ -25761,22 +25067,6 @@
 				"js-sha3": "^0.8.0"
 			},
 			"dependencies": {
-				"@ethersproject/abi": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
-					"integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
-					"requires": {
-						"@ethersproject/address": "^5.4.0",
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/constants": "^5.4.0",
-						"@ethersproject/hash": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0"
-					}
-				},
 				"@ethersproject/abstract-provider": {
 					"version": "5.4.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
@@ -25803,35 +25093,6 @@
 						"@ethersproject/properties": "^5.4.0"
 					}
 				},
-				"@ethersproject/address": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
-					"integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
-					"requires": {
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/rlp": "^5.4.0"
-					}
-				},
-				"@ethersproject/base64": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
-					"integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0"
-					}
-				},
-				"@ethersproject/basex": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
-					"integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0"
-					}
-				},
 				"@ethersproject/bignumber": {
 					"version": "5.4.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
@@ -25840,22 +25101,6 @@
 						"@ethersproject/bytes": "^5.4.0",
 						"@ethersproject/logger": "^5.4.0",
 						"bn.js": "^4.11.9"
-					}
-				},
-				"@ethersproject/bytes": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
-					"integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
-					"requires": {
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/constants": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
-					"integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
-					"requires": {
-						"@ethersproject/bignumber": "^5.4.0"
 					}
 				},
 				"@ethersproject/contracts": {
@@ -25875,102 +25120,10 @@
 						"@ethersproject/transactions": "^5.4.0"
 					}
 				},
-				"@ethersproject/hash": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
-					"integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.4.0",
-						"@ethersproject/address": "^5.4.0",
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0"
-					}
-				},
-				"@ethersproject/hdnode": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
-					"integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.4.0",
-						"@ethersproject/basex": "^5.4.0",
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/pbkdf2": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/sha2": "^5.4.0",
-						"@ethersproject/signing-key": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0",
-						"@ethersproject/transactions": "^5.4.0",
-						"@ethersproject/wordlists": "^5.4.0"
-					}
-				},
-				"@ethersproject/json-wallets": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
-					"integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.4.0",
-						"@ethersproject/address": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/hdnode": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/pbkdf2": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/random": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0",
-						"@ethersproject/transactions": "^5.4.0",
-						"aes-js": "3.0.0",
-						"scrypt-js": "3.0.1"
-					}
-				},
-				"@ethersproject/keccak256": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
-					"integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"js-sha3": "0.5.7"
-					},
-					"dependencies": {
-						"js-sha3": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-							"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-						}
-					}
-				},
-				"@ethersproject/logger": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
-					"integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
-				},
 				"@ethersproject/networks": {
 					"version": "5.4.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
 					"integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
-					"requires": {
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/pbkdf2": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
-					"integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/sha2": "^5.4.0"
-					}
-				},
-				"@ethersproject/properties": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
-					"integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
 					"requires": {
 						"@ethersproject/logger": "^5.4.0"
 					}
@@ -25999,155 +25152,6 @@
 						"@ethersproject/web": "^5.4.0",
 						"bech32": "1.1.4",
 						"ws": "7.4.6"
-					}
-				},
-				"@ethersproject/random": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
-					"integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/rlp": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
-					"integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/sha2": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
-					"integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"hash.js": "1.1.7"
-					}
-				},
-				"@ethersproject/signing-key": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
-					"integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"bn.js": "^4.11.9",
-						"elliptic": "6.5.4",
-						"hash.js": "1.1.7"
-					}
-				},
-				"@ethersproject/solidity": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
-					"integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
-					"requires": {
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/sha2": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0"
-					}
-				},
-				"@ethersproject/strings": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
-					"integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/constants": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/transactions": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
-					"integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
-					"requires": {
-						"@ethersproject/address": "^5.4.0",
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/constants": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/rlp": "^5.4.0",
-						"@ethersproject/signing-key": "^5.4.0"
-					}
-				},
-				"@ethersproject/units": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
-					"integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
-					"requires": {
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/constants": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/wallet": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
-					"integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
-					"requires": {
-						"@ethersproject/abstract-provider": "^5.4.0",
-						"@ethersproject/abstract-signer": "^5.4.0",
-						"@ethersproject/address": "^5.4.0",
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/hash": "^5.4.0",
-						"@ethersproject/hdnode": "^5.4.0",
-						"@ethersproject/json-wallets": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/random": "^5.4.0",
-						"@ethersproject/signing-key": "^5.4.0",
-						"@ethersproject/transactions": "^5.4.0",
-						"@ethersproject/wordlists": "^5.4.0"
-					}
-				},
-				"@ethersproject/web": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
-					"integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
-					"requires": {
-						"@ethersproject/base64": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0"
-					}
-				},
-				"@ethersproject/wordlists": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
-					"integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/hash": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0"
-					}
-				},
-				"elliptic": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-					"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-					"requires": {
-						"bn.js": "^4.11.9",
-						"brorand": "^1.1.0",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.1",
-						"inherits": "^2.0.4",
-						"minimalistic-assert": "^1.0.1",
-						"minimalistic-crypto-utils": "^1.0.1"
 					}
 				},
 				"ethers": {
@@ -26191,12 +25195,6 @@
 					"version": "0.8.0",
 					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
 					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-				},
-				"ws": {
-					"version": "7.4.6",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-					"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-					"requires": {}
 				}
 			}
 		},
@@ -26280,379 +25278,371 @@
 			}
 		},
 		"@ethersproject/abi": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.10.tgz",
-			"integrity": "sha512-cfC3lGgotfxX3SMri4+CisOPwignoj/QGHW9J29spC4R4Qqcnk/SYuVkPFBMdLbvBp3f/pGiVqPNwont0TSXhg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
+			"integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
 			"requires": {
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/hash": "^5.0.10",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8"
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/hash": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0"
 			}
 		},
 		"@ethersproject/abstract-provider": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
-			"integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz",
+			"integrity": "sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==",
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/networks": "^5.0.7",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/transactions": "^5.0.9",
-				"@ethersproject/web": "^5.0.12"
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/networks": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0",
+				"@ethersproject/web": "^5.4.0"
 			}
 		},
 		"@ethersproject/abstract-signer": {
-			"version": "5.0.11",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.11.tgz",
-			"integrity": "sha512-RKOgPSEYafknA62SrD3OCK42AllHE4YBfKYXyQeM+sBP7Nq3X5FpzeoY4uzC43P4wIhmNoTHCKQuwnX7fBqb6Q==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz",
+			"integrity": "sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==",
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.8",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7"
+				"@ethersproject/abstract-provider": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0"
 			}
 		},
 		"@ethersproject/address": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
-			"integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+			"integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/rlp": "^5.0.7"
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/rlp": "^5.4.0"
 			}
 		},
 		"@ethersproject/base64": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
-			"integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+			"integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9"
+				"@ethersproject/bytes": "^5.4.0"
 			}
 		},
 		"@ethersproject/basex": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.7.tgz",
-			"integrity": "sha512-OsXnRsujGmYD9LYyJlX+cVe5KfwgLUbUJrJMWdzRWogrygXd5HvGd7ygX1AYjlu1z8W/+t2FoQnczDR/H2iBjA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
+			"integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/properties": "^5.0.7"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0"
 			}
 		},
 		"@ethersproject/bignumber": {
-			"version": "5.0.13",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
-			"integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.0.tgz",
+			"integrity": "sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"bn.js": "^4.4.0"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"bn.js": "^4.11.9"
 			}
 		},
 		"@ethersproject/bytes": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
-			"integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+			"integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
 			"requires": {
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"@ethersproject/constants": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
-			"integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+			"integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.13"
+				"@ethersproject/bignumber": "^5.4.0"
 			}
 		},
 		"@ethersproject/contracts": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.9.tgz",
-			"integrity": "sha512-CCTxVeDh6sjdSEbjzONhtwPjECvaHE62oGkY8M7kP0CHmgLD2SEGel0HZib8e5oQKRKGly9AKcUFW4g3rQ0AQw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.0.tgz",
+			"integrity": "sha512-hkO3L3IhS1Z3ZtHtaAG/T87nQ7KiPV+/qnvutag35I0IkiQ8G3ZpCQ9NNOpSCzn4pWSW4CfzmtE02FcqnLI+hw==",
 			"requires": {
-				"@ethersproject/abi": "^5.0.10",
-				"@ethersproject/abstract-provider": "^5.0.8",
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7"
+				"@ethersproject/abi": "^5.4.0",
+				"@ethersproject/abstract-provider": "^5.4.0",
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0"
 			}
 		},
 		"@ethersproject/hash": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
-			"integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+			"integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8"
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0"
 			}
 		},
 		"@ethersproject/hdnode": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.8.tgz",
-			"integrity": "sha512-Mscpjd7BBjxYSWghaNMwV0xrBBkOoCq6YEPRm9MgE24CiBlzzbfEB5DGq6hiZqhQaxPkdCUtKKqZi3nt9hx43g==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
+			"integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/basex": "^5.0.7",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/pbkdf2": "^5.0.7",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/sha2": "^5.0.7",
-				"@ethersproject/signing-key": "^5.0.8",
-				"@ethersproject/strings": "^5.0.8",
-				"@ethersproject/transactions": "^5.0.9",
-				"@ethersproject/wordlists": "^5.0.8"
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/basex": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/pbkdf2": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/sha2": "^5.4.0",
+				"@ethersproject/signing-key": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0",
+				"@ethersproject/wordlists": "^5.4.0"
 			}
 		},
 		"@ethersproject/json-wallets": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.10.tgz",
-			"integrity": "sha512-Ux36u+d7Dm0M5AQ+mWuHdvfGPMN8K1aaLQgwzrsD4ELTWlwRuHuQbmn7/GqeOpbfaV6POLwdYcBk2TXjlGp/IQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
+			"integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/hdnode": "^5.0.8",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/pbkdf2": "^5.0.7",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/random": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8",
-				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/hdnode": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/pbkdf2": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/random": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0",
 				"aes-js": "3.0.0",
 				"scrypt-js": "3.0.1"
 			}
 		},
 		"@ethersproject/keccak256": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
-			"integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+			"integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/bytes": "^5.4.0",
 				"js-sha3": "0.5.7"
 			}
 		},
 		"@ethersproject/logger": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-			"integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+			"integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
 		},
 		"@ethersproject/networks": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
-			"integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.1.tgz",
+			"integrity": "sha512-8SvowCKz9Uf4xC5DTKI8+il8lWqOr78kmiqAVLYT9lzB8aSmJHQMD1GSuJI0CW4hMAnzocpGpZLgiMdzsNSPig==",
 			"requires": {
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"@ethersproject/pbkdf2": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.7.tgz",
-			"integrity": "sha512-0SNLNixPMqnosH6pyc4yPiUu/C9/Jbu+f6I8GJW9U2qNpMBddmRJviwseoha5Zw1V+Aw0Z/yvYyzIIE8yPXqLA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
+			"integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/sha2": "^5.0.7"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/sha2": "^5.4.0"
 			}
 		},
 		"@ethersproject/properties": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
-			"integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
+			"integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
 			"requires": {
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"@ethersproject/providers": {
-			"version": "5.0.19",
-			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.19.tgz",
-			"integrity": "sha512-G+flo1jK1y/rvQy6b71+Nu7qOlkOKz+XqpgqFMZslkCzGuzQRmk9Qp7Ln4soK8RSyP1e5TCujaRf1H+EZahoaw==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.1.tgz",
+			"integrity": "sha512-p06eiFKz8nu/5Ju0kIX024gzEQIgE5pvvGrBCngpyVjpuLtUIWT3097Agw4mTn9/dEA0FMcfByzFqacBMSgCVg==",
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.8",
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/basex": "^5.0.7",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/hash": "^5.0.10",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/networks": "^5.0.7",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/random": "^5.0.7",
-				"@ethersproject/rlp": "^5.0.7",
-				"@ethersproject/sha2": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8",
-				"@ethersproject/transactions": "^5.0.9",
-				"@ethersproject/web": "^5.0.12",
+				"@ethersproject/abstract-provider": "^5.4.0",
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/basex": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/hash": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/networks": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/random": "^5.4.0",
+				"@ethersproject/rlp": "^5.4.0",
+				"@ethersproject/sha2": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0",
+				"@ethersproject/web": "^5.4.0",
 				"bech32": "1.1.4",
-				"ws": "7.2.3"
+				"ws": "7.4.6"
 			}
 		},
 		"@ethersproject/random": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.7.tgz",
-			"integrity": "sha512-PxSRWwN3s+FH9AWMZU6AcWJsNQ9KzqKV6NgdeKPtxahdDjCuXxTAuzTZNXNRK+qj+Il351UnweAGd+VuZcOAlQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
+			"integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"@ethersproject/rlp": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
-			"integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+			"integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"@ethersproject/sha2": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.7.tgz",
-			"integrity": "sha512-MbUqz68hhp5RsaZdqi1eg1rrtiqt5wmhRYqdA7MX8swBkzW2KiLgK+Oh25UcWhUhdi1ImU9qrV6if5j0cC7Bxg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
+			"integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"hash.js": "1.1.3"
-			},
-			"dependencies": {
-				"hash.js": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"minimalistic-assert": "^1.0.0"
-					}
-				}
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"hash.js": "1.1.7"
 			}
 		},
 		"@ethersproject/signing-key": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
-			"integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+			"integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"elliptic": "6.5.3"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"bn.js": "^4.11.9",
+				"elliptic": "6.5.4",
+				"hash.js": "1.1.7"
 			}
 		},
 		"@ethersproject/solidity": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.8.tgz",
-			"integrity": "sha512-OJkyBq9KaoGsi8E8mYn6LX+vKyCURvxSp0yuGBcOqEFM3vkn9PsCiXsHdOXdNBvlHG5evJXwAYC2UR0TzgJeKA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
+			"integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/sha2": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8"
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/sha2": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0"
 			}
 		},
 		"@ethersproject/strings": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
-			"integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+			"integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"@ethersproject/transactions": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
-			"integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+			"integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
 			"requires": {
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/rlp": "^5.0.7",
-				"@ethersproject/signing-key": "^5.0.8"
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/rlp": "^5.4.0",
+				"@ethersproject/signing-key": "^5.4.0"
 			}
 		},
 		"@ethersproject/units": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.9.tgz",
-			"integrity": "sha512-4jIkcMVrJ3lCgXMO4M/2ww0/T/IN08vJTZld7FIAwa6aoBDTAy71+sby3sShl1SG3HEeKYbI3fBWauCUgPRUpQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
+			"integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/constants": "^5.0.8",
-				"@ethersproject/logger": "^5.0.8"
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/constants": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0"
 			}
 		},
 		"@ethersproject/wallet": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.10.tgz",
-			"integrity": "sha512-5siYr38NhqZKH6DUr6u4PdhgOKur8Q6sw+JID2TitEUmW0tOl8f6rpxAe77tw6SJT60D2UcvgsyLtl32+Nl+ig==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
+			"integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.8",
-				"@ethersproject/abstract-signer": "^5.0.10",
-				"@ethersproject/address": "^5.0.9",
-				"@ethersproject/bignumber": "^5.0.13",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/hash": "^5.0.10",
-				"@ethersproject/hdnode": "^5.0.8",
-				"@ethersproject/json-wallets": "^5.0.10",
-				"@ethersproject/keccak256": "^5.0.7",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/random": "^5.0.7",
-				"@ethersproject/signing-key": "^5.0.8",
-				"@ethersproject/transactions": "^5.0.9",
-				"@ethersproject/wordlists": "^5.0.8"
+				"@ethersproject/abstract-provider": "^5.4.0",
+				"@ethersproject/abstract-signer": "^5.4.0",
+				"@ethersproject/address": "^5.4.0",
+				"@ethersproject/bignumber": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/hash": "^5.4.0",
+				"@ethersproject/hdnode": "^5.4.0",
+				"@ethersproject/json-wallets": "^5.4.0",
+				"@ethersproject/keccak256": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/random": "^5.4.0",
+				"@ethersproject/signing-key": "^5.4.0",
+				"@ethersproject/transactions": "^5.4.0",
+				"@ethersproject/wordlists": "^5.4.0"
 			}
 		},
 		"@ethersproject/web": {
-			"version": "5.0.12",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
-			"integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+			"integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
 			"requires": {
-				"@ethersproject/base64": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8"
+				"@ethersproject/base64": "^5.4.0",
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0"
 			}
 		},
 		"@ethersproject/wordlists": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.8.tgz",
-			"integrity": "sha512-px2mloc1wAcdTbzv0ZotTx+Uh/dfnDO22D9Rx8xr7+/PUwAhZQjoJ9t7Hn72nsaN83rWBXsLvFcIRZju4GIaEQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
+			"integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.9",
-				"@ethersproject/hash": "^5.0.10",
-				"@ethersproject/logger": "^5.0.8",
-				"@ethersproject/properties": "^5.0.7",
-				"@ethersproject/strings": "^5.0.8"
+				"@ethersproject/bytes": "^5.4.0",
+				"@ethersproject/hash": "^5.4.0",
+				"@ethersproject/logger": "^5.4.0",
+				"@ethersproject/properties": "^5.4.0",
+				"@ethersproject/strings": "^5.4.0"
 			}
 		},
 		"@gnosis.pm/safe-apps-provider": {
@@ -27454,51 +26444,51 @@
 			}
 		},
 		"@synthetixio/contracts-interface": {
-			"version": "2.45.2",
-			"resolved": "https://registry.npmjs.org/@synthetixio/contracts-interface/-/contracts-interface-2.45.2.tgz",
-			"integrity": "sha512-c27pLIIwNlZiNEAG1gREX8BewDWcr+L37a7+qL2ME7HwsliM5PM3/L3tNOpQ53vW/CacRvBRWLDcbjqp57gk7A==",
+			"version": "2.47.0-ovm.5",
+			"resolved": "https://registry.npmjs.org/@synthetixio/contracts-interface/-/contracts-interface-2.47.0-ovm.5.tgz",
+			"integrity": "sha512-yzvaLyJyUxZAZH7cSLLI8HKA1j9svxsiJ+DjGLXDzOEadhfUPGPGGaMwQ+l1JSkiyUNw7qNHplg8myjcSHeL6w==",
 			"requires": {
-				"ethers": "5.0.26",
+				"ethers": "5.4.1",
 				"lodash": "4.17.19",
-				"synthetix": "2.45.2",
+				"synthetix": "2.47.0-ovm",
 				"web3-utils": "1.2.11"
 			},
 			"dependencies": {
 				"ethers": {
-					"version": "5.0.26",
-					"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.26.tgz",
-					"integrity": "sha512-MqA8Fvutn3qEW0yBJOHeV6KZmRpF2rqlL2B5058AGkUFsuu6j5Ns/FRlMsbGeQwBz801IB23jQp7vjRfFsKSkg==",
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.1.tgz",
+					"integrity": "sha512-SrcddMdCgP1hukDvCPd87Aipbf4NWjQvdfAbZ65XSZGbfyuYPtIrUJPDH5B1SBRsdlfiEgX3eoz28DdBDzMNFg==",
 					"requires": {
-						"@ethersproject/abi": "5.0.10",
-						"@ethersproject/abstract-provider": "5.0.8",
-						"@ethersproject/abstract-signer": "5.0.11",
-						"@ethersproject/address": "5.0.9",
-						"@ethersproject/base64": "5.0.7",
-						"@ethersproject/basex": "5.0.7",
-						"@ethersproject/bignumber": "5.0.13",
-						"@ethersproject/bytes": "5.0.9",
-						"@ethersproject/constants": "5.0.8",
-						"@ethersproject/contracts": "5.0.9",
-						"@ethersproject/hash": "5.0.10",
-						"@ethersproject/hdnode": "5.0.8",
-						"@ethersproject/json-wallets": "5.0.10",
-						"@ethersproject/keccak256": "5.0.7",
-						"@ethersproject/logger": "5.0.8",
-						"@ethersproject/networks": "5.0.7",
-						"@ethersproject/pbkdf2": "5.0.7",
-						"@ethersproject/properties": "5.0.7",
-						"@ethersproject/providers": "5.0.19",
-						"@ethersproject/random": "5.0.7",
-						"@ethersproject/rlp": "5.0.7",
-						"@ethersproject/sha2": "5.0.7",
-						"@ethersproject/signing-key": "5.0.8",
-						"@ethersproject/solidity": "5.0.8",
-						"@ethersproject/strings": "5.0.8",
-						"@ethersproject/transactions": "5.0.9",
-						"@ethersproject/units": "5.0.9",
-						"@ethersproject/wallet": "5.0.10",
-						"@ethersproject/web": "5.0.12",
-						"@ethersproject/wordlists": "5.0.8"
+						"@ethersproject/abi": "5.4.0",
+						"@ethersproject/abstract-provider": "5.4.0",
+						"@ethersproject/abstract-signer": "5.4.0",
+						"@ethersproject/address": "5.4.0",
+						"@ethersproject/base64": "5.4.0",
+						"@ethersproject/basex": "5.4.0",
+						"@ethersproject/bignumber": "5.4.0",
+						"@ethersproject/bytes": "5.4.0",
+						"@ethersproject/constants": "5.4.0",
+						"@ethersproject/contracts": "5.4.0",
+						"@ethersproject/hash": "5.4.0",
+						"@ethersproject/hdnode": "5.4.0",
+						"@ethersproject/json-wallets": "5.4.0",
+						"@ethersproject/keccak256": "5.4.0",
+						"@ethersproject/logger": "5.4.0",
+						"@ethersproject/networks": "5.4.1",
+						"@ethersproject/pbkdf2": "5.4.0",
+						"@ethersproject/properties": "5.4.0",
+						"@ethersproject/providers": "5.4.1",
+						"@ethersproject/random": "5.4.0",
+						"@ethersproject/rlp": "5.4.0",
+						"@ethersproject/sha2": "5.4.0",
+						"@ethersproject/signing-key": "5.4.0",
+						"@ethersproject/solidity": "5.4.0",
+						"@ethersproject/strings": "5.4.0",
+						"@ethersproject/transactions": "5.4.0",
+						"@ethersproject/units": "5.4.0",
+						"@ethersproject/wallet": "5.4.0",
+						"@ethersproject/web": "5.4.0",
+						"@ethersproject/wordlists": "5.4.0"
 					}
 				},
 				"lodash": {
@@ -27524,20 +26514,6 @@
 					"version": "8.4.1",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
 					"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA=="
-				},
-				"elliptic": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-					"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-					"requires": {
-						"bn.js": "^4.11.9",
-						"brorand": "^1.1.0",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.1",
-						"inherits": "^2.0.4",
-						"minimalistic-assert": "^1.0.1",
-						"minimalistic-crypto-utils": "^1.0.1"
-					}
 				},
 				"secp256k1": {
 					"version": "3.8.0",
@@ -27650,27 +26626,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
 					"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-				},
-				"elliptic": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-					"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-					"requires": {
-						"bn.js": "^4.11.9",
-						"brorand": "^1.1.0",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.1",
-						"inherits": "^2.0.4",
-						"minimalistic-assert": "^1.0.1",
-						"minimalistic-crypto-utils": "^1.0.1"
-					},
-					"dependencies": {
-						"bn.js": {
-							"version": "4.12.0",
-							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-						}
-					}
 				},
 				"web3-utils": {
 					"version": "1.5.1",
@@ -30248,8 +29203,7 @@
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-			"dev": true
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 		},
 		"checkpoint-store": {
 			"version": "1.1.0",
@@ -30978,14 +29932,15 @@
 			"integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
 		},
 		"css-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-			"integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+			"integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
 			"requires": {
 				"boolbase": "^1.0.0",
-				"css-what": "^3.2.1",
-				"domutils": "^1.7.0",
-				"nth-check": "^1.0.2"
+				"css-what": "^5.0.0",
+				"domhandler": "^4.2.0",
+				"domutils": "^2.6.0",
+				"nth-check": "^2.0.0"
 			}
 		},
 		"css-to-react-native": {
@@ -31008,9 +29963,9 @@
 			}
 		},
 		"css-what": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-			"integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ=="
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+			"integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
 		},
 		"css.escape": {
 			"version": "1.5.1",
@@ -31424,11 +30379,12 @@
 			}
 		},
 		"dom-serializer": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+			"integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
 			"requires": {
 				"domelementtype": "^2.0.1",
+				"domhandler": "^4.2.0",
 				"entities": "^2.0.0"
 			}
 		},
@@ -31448,34 +30404,21 @@
 			"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
 		},
 		"domhandler": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+			"integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
 			"requires": {
-				"domelementtype": "1"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-					"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-				}
+				"domelementtype": "^2.2.0"
 			}
 		},
 		"domutils": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+			"integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
 			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-					"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-				}
+				"dom-serializer": "^1.0.1",
+				"domelementtype": "^2.2.0",
+				"domhandler": "^4.2.0"
 			}
 		},
 		"drbg.js": {
@@ -31570,17 +30513,17 @@
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
 			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
 				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"emoji-regex": {
@@ -33428,7 +32371,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
 			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"dev": true,
 			"requires": {
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
@@ -34761,22 +33703,6 @@
 				"superagent": "^3.8.3"
 			},
 			"dependencies": {
-				"@ethersproject/abi": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
-					"integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
-					"requires": {
-						"@ethersproject/address": "^5.4.0",
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/constants": "^5.4.0",
-						"@ethersproject/hash": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0"
-					}
-				},
 				"@ethersproject/abstract-provider": {
 					"version": "5.4.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
@@ -34803,35 +33729,6 @@
 						"@ethersproject/properties": "^5.4.0"
 					}
 				},
-				"@ethersproject/address": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
-					"integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
-					"requires": {
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/rlp": "^5.4.0"
-					}
-				},
-				"@ethersproject/base64": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
-					"integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0"
-					}
-				},
-				"@ethersproject/basex": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
-					"integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0"
-					}
-				},
 				"@ethersproject/bignumber": {
 					"version": "5.4.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
@@ -34840,22 +33737,6 @@
 						"@ethersproject/bytes": "^5.4.0",
 						"@ethersproject/logger": "^5.4.0",
 						"bn.js": "^4.11.9"
-					}
-				},
-				"@ethersproject/bytes": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
-					"integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
-					"requires": {
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/constants": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
-					"integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
-					"requires": {
-						"@ethersproject/bignumber": "^5.4.0"
 					}
 				},
 				"@ethersproject/contracts": {
@@ -34875,109 +33756,10 @@
 						"@ethersproject/transactions": "^5.4.0"
 					}
 				},
-				"@ethersproject/hash": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
-					"integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.4.0",
-						"@ethersproject/address": "^5.4.0",
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0"
-					}
-				},
-				"@ethersproject/hdnode": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
-					"integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.4.0",
-						"@ethersproject/basex": "^5.4.0",
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/pbkdf2": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/sha2": "^5.4.0",
-						"@ethersproject/signing-key": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0",
-						"@ethersproject/transactions": "^5.4.0",
-						"@ethersproject/wordlists": "^5.4.0"
-					}
-				},
-				"@ethersproject/json-wallets": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
-					"integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.4.0",
-						"@ethersproject/address": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/hdnode": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/pbkdf2": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/random": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0",
-						"@ethersproject/transactions": "^5.4.0",
-						"aes-js": "3.0.0",
-						"scrypt-js": "3.0.1"
-					},
-					"dependencies": {
-						"aes-js": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-							"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
-						}
-					}
-				},
-				"@ethersproject/keccak256": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
-					"integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"js-sha3": "0.5.7"
-					},
-					"dependencies": {
-						"js-sha3": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-							"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-						}
-					}
-				},
-				"@ethersproject/logger": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
-					"integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
-				},
 				"@ethersproject/networks": {
 					"version": "5.4.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
 					"integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
-					"requires": {
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/pbkdf2": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
-					"integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/sha2": "^5.4.0"
-					}
-				},
-				"@ethersproject/properties": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
-					"integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
 					"requires": {
 						"@ethersproject/logger": "^5.4.0"
 					}
@@ -35015,141 +33797,6 @@
 						}
 					}
 				},
-				"@ethersproject/random": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
-					"integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/rlp": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
-					"integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/sha2": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
-					"integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"hash.js": "1.1.7"
-					}
-				},
-				"@ethersproject/signing-key": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
-					"integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"bn.js": "^4.11.9",
-						"elliptic": "6.5.4",
-						"hash.js": "1.1.7"
-					}
-				},
-				"@ethersproject/solidity": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
-					"integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
-					"requires": {
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/sha2": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0"
-					}
-				},
-				"@ethersproject/strings": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
-					"integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/constants": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/transactions": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
-					"integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
-					"requires": {
-						"@ethersproject/address": "^5.4.0",
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/constants": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/rlp": "^5.4.0",
-						"@ethersproject/signing-key": "^5.4.0"
-					}
-				},
-				"@ethersproject/units": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
-					"integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
-					"requires": {
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/constants": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0"
-					}
-				},
-				"@ethersproject/wallet": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
-					"integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
-					"requires": {
-						"@ethersproject/abstract-provider": "^5.4.0",
-						"@ethersproject/abstract-signer": "^5.4.0",
-						"@ethersproject/address": "^5.4.0",
-						"@ethersproject/bignumber": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/hash": "^5.4.0",
-						"@ethersproject/hdnode": "^5.4.0",
-						"@ethersproject/json-wallets": "^5.4.0",
-						"@ethersproject/keccak256": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/random": "^5.4.0",
-						"@ethersproject/signing-key": "^5.4.0",
-						"@ethersproject/transactions": "^5.4.0",
-						"@ethersproject/wordlists": "^5.4.0"
-					}
-				},
-				"@ethersproject/web": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
-					"integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
-					"requires": {
-						"@ethersproject/base64": "^5.4.0",
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0"
-					}
-				},
-				"@ethersproject/wordlists": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
-					"integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
-					"requires": {
-						"@ethersproject/bytes": "^5.4.0",
-						"@ethersproject/hash": "^5.4.0",
-						"@ethersproject/logger": "^5.4.0",
-						"@ethersproject/properties": "^5.4.0",
-						"@ethersproject/strings": "^5.4.0"
-					}
-				},
 				"aes-js": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
@@ -35164,20 +33811,6 @@
 					"version": "9.0.1",
 					"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
 					"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
-				},
-				"elliptic": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-					"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-					"requires": {
-						"bn.js": "^4.11.9",
-						"brorand": "^1.1.0",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.1",
-						"inherits": "^2.0.4",
-						"minimalistic-assert": "^1.0.1",
-						"minimalistic-crypto-utils": "^1.0.1"
-					}
 				},
 				"ethers": {
 					"version": "5.4.4",
@@ -35220,12 +33853,6 @@
 					"version": "0.8.0",
 					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
 					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-				},
-				"ws": {
-					"version": "7.4.6",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-					"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-					"requires": {}
 				}
 			}
 		},
@@ -35422,28 +34049,14 @@
 			}
 		},
 		"htmlparser2": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+			"integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
 			"requires": {
-				"domelementtype": "^1.3.1",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.1.1"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-					"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-				},
-				"entities": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-					"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
-				}
+				"domelementtype": "^2.0.1",
+				"domhandler": "^4.0.0",
+				"domutils": "^2.5.2",
+				"entities": "^2.0.0"
 			}
 		},
 		"http-https": {
@@ -35567,7 +34180,6 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -36187,6 +34799,11 @@
 					}
 				}
 			}
+		},
+		"js-levenshtein": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+			"integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
 		},
 		"js-sha3": {
 			"version": "0.5.7",
@@ -38233,11 +36850,11 @@
 			}
 		},
 		"nth-check": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+			"integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
 			"requires": {
-				"boolbase": "~1.0.0"
+				"boolbase": "^1.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -38526,8 +37143,7 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -39707,21 +38323,26 @@
 			"optional": true
 		},
 		"renderkid": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.5.tgz",
-			"integrity": "sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
+			"integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
 			"requires": {
-				"css-select": "^2.0.2",
-				"dom-converter": "^0.2",
-				"htmlparser2": "^3.10.1",
-				"lodash": "^4.17.20",
-				"strip-ansi": "^3.0.0"
+				"css-select": "^4.1.3",
+				"dom-converter": "^0.2.0",
+				"htmlparser2": "^6.1.0",
+				"lodash": "^4.17.21",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
@@ -39974,8 +38595,7 @@
 		"run-async": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-			"dev": true
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
 		},
 		"run-queue": {
 			"version": "1.0.3",
@@ -41278,21 +39898,47 @@
 			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
 		},
 		"synthetix": {
-			"version": "2.45.2",
-			"resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.45.2.tgz",
-			"integrity": "sha512-m3QZnXXQ8ls09qRoyrlCwHlaS5m4aFtDgZWBRONc+d5img6LQbH/Y9biZk0fZ0Ccr6nhc5yj4BcVuXEajufCZw==",
+			"version": "2.47.0-ovm",
+			"resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.47.0-ovm.tgz",
+			"integrity": "sha512-YCcNhZdCgoT4dcXHS6YWavNDLDIthAEr8/fs0+BqfT7/vf+Ny1X7Zq0+qg6gRZpKBKDFiD9iyT1YFzF7z1gc2Q==",
 			"requires": {
 				"abi-decoder": "2.3.0",
 				"commander": "5.1.0",
+				"inquirer": "^6.5.2",
+				"inquirer-list-search-prompt": "^1.0.2",
+				"js-levenshtein": "^1.1.6",
 				"pretty-error": "^2.1.1",
 				"solidity-parser-antlr": "^0.4.11",
 				"web3-utils": "1.2.2"
 			},
 			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				},
 				"bn.js": {
 					"version": "4.11.8",
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
 					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+				},
+				"cli-cursor": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+					"requires": {
+						"restore-cursor": "^2.0.0"
+					}
+				},
+				"cli-width": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+					"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
 				},
 				"eth-lib": {
 					"version": "0.2.7",
@@ -41302,6 +39948,80 @@
 						"bn.js": "^4.11.6",
 						"elliptic": "^6.4.0",
 						"xhr-request-promise": "^0.1.2"
+					}
+				},
+				"figures": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"requires": {
+						"escape-string-regexp": "^1.0.5"
+					}
+				},
+				"inquirer": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+					"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+					"requires": {
+						"ansi-escapes": "^3.2.0",
+						"chalk": "^2.4.2",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.3",
+						"figures": "^2.0.0",
+						"lodash": "^4.17.12",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^6.4.0",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^5.1.0",
+						"through": "^2.3.6"
+					}
+				},
+				"inquirer-list-search-prompt": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/inquirer-list-search-prompt/-/inquirer-list-search-prompt-1.0.2.tgz",
+					"integrity": "sha512-p2pxuhxCurxZbWkYydLaI+9f2qkSDQUB2MeIJ07jxNBqH/bkHcz7Kk78+Im/XnL1MdyHbh0KKMzjAHmeSLn7oA==",
+					"requires": {
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"figures": "^2.0.0",
+						"run-async": "^2.3.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+				},
+				"mute-stream": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+				},
+				"onetime": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"restore-cursor": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+					"requires": {
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"requires": {
+						"ansi-regex": "^4.1.0"
 					}
 				},
 				"web3-utils": {
@@ -41652,8 +40372,7 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -41727,7 +40446,6 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -43392,9 +42110,10 @@
 			}
 		},
 		"ws": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+			"version": "7.4.6",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+			"requires": {}
 		},
 		"xhr": {
 			"version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"dependencies": {
 		"@material-ui/core": "4.11.0",
 		"@material-ui/lab": "4.0.0-alpha.56",
-		"@synthetixio/contracts-interface": "2.45.2",
+		"@synthetixio/contracts-interface": "2.47.0-ovm.5",
 		"axios": "0.21.1",
 		"bignumber.js": "9.0.0",
 		"bnc-notify": "1.3.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -32,6 +32,7 @@ export const headersAndScrollRef: { [key: string]: RefObject<unknown> } = {
 	'YIELD FARMING': createRef(),
 	SYNTHS: createRef(),
 	OPTIONS: createRef(),
+	L2: createRef(),
 };
 
 const provider = new ethers.providers.InfuraProvider(

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -38,7 +38,11 @@ const provider = new ethers.providers.InfuraProvider(
 	'homestead',
 	process.env.NEXT_PUBLIC_INFURA_KEY
 );
-export const ProviderContext = createContext(provider);
+
+const providerl2 = new ethers.providers.JsonRpcProvider('https://mainnet.optimism.io');
+
+export const ProviderContext = createContext(provider as ethers.providers.Provider);
+export const ProviderContextL2 = createContext(providerl2 as ethers.providers.Provider);
 
 export const HeadersContext = createContext(headersAndScrollRef);
 
@@ -55,8 +59,10 @@ const queryClient = new QueryClient({
 let checkInterval: any = null;
 
 const snxjs = synthetix({ network: Network.Mainnet, provider });
+const snxjsl2 = synthetix({ network: Network['Mainnet-Ovm'], provider: providerl2 });
 
 export const SNXJSContext = createContext(snxjs);
+export const SNXJSContextL2 = createContext(snxjsl2);
 
 const App: FC<AppProps> = ({ Component, pageProps }) => {
 	const { t } = useTranslation();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,10 +31,13 @@ const HomePage: FC = () => {
 				<YieldFarmingSection />
 			</div>
 			<div ref={headersContext.SYNTHS as React.RefObject<HTMLDivElement>}>
-				<SynthsSection />
+				<SynthsSection l2={false} />
 			</div>
 			<div ref={headersContext.OPTIONS as React.RefObject<HTMLDivElement>}>
 				<OptionsSection />
+			</div>
+			<div ref={headersContext.L2 as React.RefObject<HTMLDivElement>}>
+				<SynthsSection l2={true} />
 			</div>
 		</>
 	);

--- a/queries/shared/useSnxjsContractQuery.ts
+++ b/queries/shared/useSnxjsContractQuery.ts
@@ -9,7 +9,7 @@ export const useSnxjsContractQuery = <T>(
 	method: string,
 	args: any[]
 ) => {
-	return useQuery<T, string>(QUERY_KEYS.SnxjsContract(contract, method, args), async () => {
+	return useQuery<T, string>(QUERY_KEYS.SnxjsContract(snxjs, contract, method, args), async () => {
 		return snxjs.contracts[contract][method](...args);
 	});
 };

--- a/sections/Synths/index.tsx
+++ b/sections/Synths/index.tsx
@@ -110,7 +110,6 @@ const SynthsSection: FC<{ l2: boolean }> = ({ l2 }) => {
 				snxjs.contracts.CollateralEth.address
 		  )
 		: null;
-	/* eslint-enable */
 
 	const etherLocked =
 		ethCollateralBalance?.isSuccess &&
@@ -121,12 +120,10 @@ const SynthsSection: FC<{ l2: boolean }> = ({ l2 }) => {
 			  Number(multiCollateralEtherBalance?.data!)
 			: null;
 
-	const unformattedWrapprLocked = useSnxjsContractQuery<ethers.BigNumber>(
-		snxjs,
-		'EtherWrapper',
-		'sETHIssued',
-		[]
-	);
+	const unformattedWrapprLocked = snxjs.contracts.EtherWrapper.sETHIssued
+		? useSnxjsContractQuery<ethers.BigNumber>(snxjs, 'EtherWrapper', 'sETHIssued', [])
+		: null;
+	/* eslint-enable */
 
 	const synthTotalSupplies = synthTotalSuppliesRequest.isSuccess
 		? synthTotalSuppliesRequest.data!
@@ -271,7 +268,7 @@ const SynthsSection: FC<{ l2: boolean }> = ({ l2 }) => {
 
 	return (
 		<>
-			<SectionHeader title={t('section-header.synths')} />
+			<SectionHeader title={l2 ? 'L2 Synths' : t('section-header.synths')} />
 			<SingleStatRow
 				text={t('total-debt.title')}
 				subtext={t('total-debt.subtext')}

--- a/sections/Synths/index.tsx
+++ b/sections/Synths/index.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 
 import SectionHeader from 'components/SectionHeader';
 import { MAX_PAGE_WIDTH, COLORS } from 'constants/styles';
-import { SNXJSContext, ProviderContext } from 'pages/_app';
+import { SNXJSContext, ProviderContext, SNXJSContextL2, ProviderContextL2 } from 'pages/_app';
 import { OpenInterest, SynthTotalSupply } from 'types/data';
 import SingleStatRow from 'components/SingleStatRow';
 import DoubleStatsBox from 'components/DoubleStatsBox';
@@ -23,6 +23,7 @@ import _ from 'lodash';
 import { useGeneralTradingInfoQuery } from 'queries/trading';
 import { useTokenBalanceQuery } from 'queries/shared/useTokenBalanceQuery';
 import { renBTC } from 'contracts';
+import { CurrencyKey } from '@synthetixio/contracts-interface';
 
 const MIN_PERCENT_FOR_PIE_CHART = 0.03;
 const NUMBER_OF_TOP_SYNTHS = 3;
@@ -41,10 +42,10 @@ function aggregateSynthTradeVolume(trades: any[]) {
 	return synthVolumes;
 }
 
-const SynthsSection: FC<{}> = () => {
+const SynthsSection: FC<{ l2: boolean }> = ({ l2 }) => {
 	const { t } = useTranslation();
-	const snxjs = useContext(SNXJSContext);
-	const provider = useContext(ProviderContext);
+	const snxjs = useContext(!l2 ? SNXJSContext : SNXJSContextL2);
+	const provider = useContext(!l2 ? ProviderContext : ProviderContextL2);
 
 	const [tradeStartTime] = useState(Math.floor(Date.now() / 1000 - 86400));
 
@@ -58,18 +59,17 @@ const SynthsSection: FC<{}> = () => {
 		'synthsTotalSupplies',
 		[]
 	);
-	const unformattedEthShorts = useSnxjsContractQuery<ethers.BigNumber>(
-		snxjs,
-		'CollateralManager',
-		'short',
-		[snxjs.toBytes32('sETH')]
-	);
-	const unformattedBtcShorts = useSnxjsContractQuery<ethers.BigNumber>(
-		snxjs,
-		'CollateralManager',
-		'short',
-		[snxjs.toBytes32('sBTC')]
-	);
+	/* eslint-disable */
+	const unformattedEthShorts = snxjs.contracts.CollateralManager
+		? useSnxjsContractQuery<ethers.BigNumber>(snxjs, 'CollateralManager', 'short', [
+				snxjs.toBytes32('sETH'),
+		  ])
+		: null;
+	const unformattedBtcShorts = snxjs.contracts.CollateralManager
+		? useSnxjsContractQuery<ethers.BigNumber>(snxjs, 'CollateralManager', 'short', [
+				snxjs.toBytes32('sBTC'),
+		  ])
+		: null;
 	const unformattedEthPrice = useSnxjsContractQuery<ethers.BigNumber>(
 		snxjs,
 		'ExchangeRates',
@@ -83,36 +83,42 @@ const SynthsSection: FC<{}> = () => {
 		[snxjs.toBytes32('sBTC')]
 	);
 
-	const bitcoinLocked = useTokenBalanceQuery(
-		provider,
-		renBTC.address,
-		snxjs.contracts.CollateralErc20.address,
-		{ decimals: 8 }
-	);
+	const bitcoinLocked = snxjs.contracts.CollateralErc20
+		? useTokenBalanceQuery(provider, renBTC.address, snxjs.contracts.CollateralErc20.address, {
+				decimals: 8,
+		  })
+		: null;
 
-	const ethSusdCollateralBalance = useTokenBalanceQuery(
-		provider,
-		ethers.constants.AddressZero,
-		snxjs.contracts.EtherCollateralsUSD.address
-	);
-	const ethCollateralBalance = useTokenBalanceQuery(
-		provider,
-		ethers.constants.AddressZero,
-		snxjs.contracts.EtherCollateral.address
-	);
-	const multiCollateralEtherBalance = useTokenBalanceQuery(
-		provider,
-		ethers.constants.AddressZero,
-		snxjs.contracts.CollateralEth.address
-	);
+	const ethSusdCollateralBalance = snxjs.contracts.EtherCollateralsUSD
+		? useTokenBalanceQuery(
+				provider,
+				ethers.constants.AddressZero,
+				snxjs.contracts.EtherCollateralsUSD.address
+		  )
+		: null;
+	const ethCollateralBalance = snxjs.contracts.EtherCollateral
+		? useTokenBalanceQuery(
+				provider,
+				ethers.constants.AddressZero,
+				snxjs.contracts.EtherCollateral.address
+		  )
+		: null;
+	const multiCollateralEtherBalance = snxjs.contracts.CollateralEth
+		? useTokenBalanceQuery(
+				provider,
+				ethers.constants.AddressZero,
+				snxjs.contracts.CollateralEth.address
+		  )
+		: null;
+	/* eslint-enable */
 
 	const etherLocked =
-		ethCollateralBalance.isSuccess &&
-		ethSusdCollateralBalance.isSuccess &&
-		multiCollateralEtherBalance.isSuccess
-			? Number(ethCollateralBalance.data!) +
-			  Number(ethSusdCollateralBalance.data!) +
-			  Number(multiCollateralEtherBalance.data!)
+		ethCollateralBalance?.isSuccess &&
+		ethSusdCollateralBalance?.isSuccess &&
+		multiCollateralEtherBalance?.isSuccess
+			? Number(ethCollateralBalance?.data!) +
+			  Number(ethSusdCollateralBalance?.data!) +
+			  Number(multiCollateralEtherBalance?.data!)
 			: null;
 
 	const unformattedWrapprLocked = useSnxjsContractQuery<ethers.BigNumber>(
@@ -143,7 +149,7 @@ const SynthsSection: FC<{}> = () => {
 		unformattedBtcPrice,
 		unformattedEthPrice,
 		unformattedWrapprLocked,
-	].map((val) => (val.isSuccess ? Number(formatEther(val.data!)) : null));
+	].map((val) => (val?.isSuccess ? Number(formatEther(val.data!)) : null));
 
 	let barChartData: OpenInterest = {};
 	let pieChartData: SynthTotalSupply[] = [];
@@ -151,13 +157,9 @@ const SynthsSection: FC<{}> = () => {
 
 	if (
 		synthTotalSupplies &&
-		ethShorts &&
-		btcShorts &&
 		ethPrice &&
 		btcPrice &&
-		etherLocked &&
-		bitcoinLocked.isSuccess &&
-		wrapprLocked
+		(l2 || (bitcoinLocked?.isSuccess && ethShorts && btcShorts && etherLocked && wrapprLocked))
 	) {
 		let totalSynthValue = 0;
 		const unsortedOpenInterest: SynthTotalSupply[] = [];
@@ -171,12 +173,16 @@ const SynthsSection: FC<{}> = () => {
 			}
 			let combinedWithExtrasValue = value;
 			if (name === 'iETH') {
-				combinedWithExtrasValue += ethShorts * ethPrice;
-				combinedWithExtrasValue += etherLocked * ethPrice;
-				combinedWithExtrasValue += wrapprLocked * ethPrice;
+				if (!l2) {
+					combinedWithExtrasValue += ethShorts! * ethPrice;
+					combinedWithExtrasValue += etherLocked! * ethPrice;
+					combinedWithExtrasValue += wrapprLocked! * ethPrice;
+				}
 			} else if (name === 'iBTC') {
-				combinedWithExtrasValue += btcShorts * btcPrice;
-				combinedWithExtrasValue += Number(bitcoinLocked.data!) * btcPrice;
+				if (!l2) {
+					combinedWithExtrasValue += btcShorts! * btcPrice;
+					combinedWithExtrasValue += Number(bitcoinLocked!.data!) * btcPrice;
+				}
 			}
 			const synthObject: SynthTotalSupply = {
 				name,
@@ -194,7 +200,7 @@ const SynthsSection: FC<{}> = () => {
 			.map(({ name }) => name);
 
 		barChartData = orderBy(unsortedOpenInterest, 'value', 'desc')
-			.filter((item) => openInterestSynths.includes(item.name))
+			.filter((item) => openInterestSynths.includes(item.name as CurrencyKey))
 			.reduce((acc: OpenInterest, curr: SynthTotalSupply): OpenInterest => {
 				const name = curr.name.slice(1);
 				const isEthShort = curr.name === 'iETH';
@@ -297,8 +303,6 @@ const SynthsSection: FC<{}> = () => {
 								secondMetricStyle="currency0"
 								queries={[
 									sUSDPriceQuery,
-									unformattedEthShorts,
-									unformattedBtcShorts,
 									unformattedBtcPrice,
 									unformattedEthPrice,
 									synthTotalSuppliesRequest,


### PR DESCRIPTION
this should be reverted once
* mitch's PR has been merged with queries integration (which allows for transparent loading of contracts)
* design has been clarified (expecting there to be a tab to switch stats to "L2 Mode" or something, basically showing the same page but for L2)

once these things are finalized, most of the effort of L2 stats will just be
adding in the UI elements for switching