### PR TITLE
Remove extraneous "$" from SynthsPieChart legend

### DIFF
--- a/sections/Synths/SynthsPieChart.tsx
+++ b/sections/Synths/SynthsPieChart.tsx
@@ -81,7 +81,7 @@ const Tooltip: FC<{ name: string; value: number; payload: { payload: SynthTotalS
 const Legend: FC<{ payload: { payload: SynthTotalSupply } }> = ({ payload: { payload } }) => {
 	return (
 		<span>
-			{formatCurrency(payload.skewValue.toNumber(), 0)} ($
+			{formatCurrency(payload.skewValue.toNumber(), 0)} (
 			{formatPercentage(payload.poolProportion.toNumber(), 0)})
 		</span>
 	);


### PR DESCRIPTION
This removes the "$" prepended to the percentages in the "Synth Dominance" section of the dashboard.

<img width="528" alt="Screen Shot 2021-09-03 at 10 30 33 AM" src="https://user-images.githubusercontent.com/335975/132022266-964307d6-f41a-4014-887a-ec533560bf09.png">
